### PR TITLE
fix: update schema to fix deprecated schema error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-appwrite"
-version = "0.3.1"
+version = "0.3.2"
 description = "MCP (Model Context Protocol) server for Appwrite"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.appwrite/mcp-for-api",
   "description": "MCP (Model Context Protocol) server for Appwrite",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "repository": {
     "url": "https://github.com/appwrite/mcp-for-api",
     "source": "github"
   },
   "packages": [
     {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "registryType": "pypi",
       "identifier": "mcp-server-appwrite",
       "transport": {

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -134,7 +134,7 @@ async def _run():
             write_stream,
             InitializationOptions(
                 server_name="appwrite",
-                server_version="0.3.1",
+                server_version="0.3.2",
                 capabilities=server.get_capabilities(
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ cli = [
 
 [[package]]
 name = "mcp-server-appwrite"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "appwrite" },


### PR DESCRIPTION
## Summary
- Migrates server.json from deprecated `2025-12-11` schema to current `2025-10-17` schema
- Fixes the `mcp-publisher publish` error: "deprecated schema detected"

## Test plan
- [ ] Run `./mcp-publisher publish` and verify no schema deprecation error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.3.2 across project configuration and server components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->