### PR TITLE
Pin appwrite below 16 to avoid tablesdb startup failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP (Model Context Protocol) server for Appwrite"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "appwrite>=13.4.1",
+    "appwrite>=13.4.1,<16",
     "docstring-parser>=0.16",
     "mcp[cli]>=1.3.0",
     "python-dotenv>=1.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -431,7 +431,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "appwrite", specifier = ">=13.4.1" },
+    { name = "appwrite", specifier = ">=13.4.1,<16" },
     { name = "argon2-cffi", marker = "extra == 'integration'", specifier = ">=23.1.0" },
     { name = "bcrypt", marker = "extra == 'integration'", specifier = ">=4.1.2" },
     { name = "docstring-parser", specifier = ">=0.16" },


### PR DESCRIPTION
## Summary

Pin the Python Appwrite SDK to `<16`.

This keeps `mcp-server-appwrite` on the last pre-strict-typing SDK line and avoids the `TablesDB.list()` startup failure some users are hitting against Appwrite Cloud.

## Why

`mcp-server-appwrite` 0.4 currently performs a minimal startup probe against `tables_db` by calling `TablesDB.list()`.

For older Python SDK versions, that call returned a raw `dict`, so malformed nested response values from `/tablesdb` were tolerated.

Starting with `appwrite` `16.0.0`, the Python SDK switched `TablesDB.list()` to parse into a typed `DatabaseList`. That makes the startup probe fail fast when Appwrite Cloud returns malformed nested values such as:

- `databases[*].policies[*].status = ""`
- `databases[*].archives[*].documentSecurity = ""`

We verified the version boundary while investigating:

- `15.3.0` still returns `Dict[str, Any]`
- `16.0.0` returns typed `DatabaseList`
- `16.0.0` and `17.0.0` both fail on the malformed synthetic `/tablesdb` payload

Pinning to `<16` is the narrowest dependency change that restores the previous behavior without changing the server code path.

## Changes

- update `pyproject.toml` to require `appwrite>=13.4.1,<16`
- refresh `uv.lock` metadata to match the new constraint

## Testing

- `uv lock`
- `uv run python -m unittest discover -s tests/unit -p 'test_server.py'`

## Notes

There is no linked issue number in this repo for this change yet. This is a compatibility pin to avoid known startup failures until the upstream response mismatch is resolved or the server is updated to handle it differently.
