### PR TITLE
Restore stdio transport for self-hosted MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   lint:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ RUN uv sync --frozen --no-dev
 
 ENV HOST=0.0.0.0 \
     PORT=8000 \
+    MCP_TRANSPORT=http \
     APPWRITE_ENDPOINT=https://cloud.appwrite.io/v1
 
 EXPOSE 8000
 
-CMD ["uv", "run", "mcp-server-appwrite"]
+CMD ["uv", "run", "mcp-server-appwrite", "--transport", "http"]

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ mcp-name: io.github.appwrite/mcp
 
 A Model Context Protocol server for interacting with Appwrite's API. It provides tools to manage databases, users, functions, teams, and more within your Appwrite project.
 
-The server is a hosted [OAuth 2.1 Resource Server](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) served over the MCP [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports) transport. It targets the Appwrite Cloud console project; users authenticate with that project's OAuth 2.1 authorization server, and no API keys are distributed to clients.
+Appwrite Cloud is available as a hosted [OAuth 2.1 Resource Server](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) over MCP [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports). Self-hosted Appwrite instances use the local MCP `stdio` transport with an Appwrite project API key.
 
 ## Quick Links
-- [Connecting a client](#connecting-a-client)
-- [How authentication works](#how-authentication-works)
+- [Cloud hosted MCP](#cloud-hosted-mcp)
+- [Self-hosted stdio MCP](#self-hosted-stdio-mcp)
+- [How Cloud authentication works](#how-cloud-authentication-works)
 - [Tool surface](#tool-surface)
 - [Local development](#local-development)
 - [Debugging](#debugging)
 
-## Connecting a client
+## Cloud hosted MCP
 
 Add the server to any MCP client that supports remote (Streamable HTTP) servers by its URL:
 
@@ -38,7 +39,46 @@ For example, in a client that accepts a JSON server config:
 
 The first time you connect, the client opens an Appwrite consent screen in your browser. Approve the requested scopes and the client is connected — there are no keys to copy.
 
-## How authentication works
+## Self-hosted stdio MCP
+
+Self-hosted users should run the MCP server locally over stdio and authenticate with a project API key from their Appwrite Console.
+
+Create a project API key with the scopes you want the MCP server to use, then configure your MCP client with:
+
+```json
+{
+  "mcpServers": {
+    "appwrite": {
+      "command": "uvx",
+      "args": ["mcp-server-appwrite"],
+      "env": {
+        "APPWRITE_PROJECT_ID": "<YOUR_PROJECT_ID>",
+        "APPWRITE_API_KEY": "<YOUR_API_KEY>",
+        "APPWRITE_ENDPOINT": "https://<YOUR_APPWRITE_DOMAIN>/v1"
+      }
+    }
+  }
+}
+```
+
+For the local Appwrite development compose setup in `/Users/chiragaggarwal/Desktop/appwrite/appwrite`, the endpoint is typically:
+
+```text
+http://localhost:9501/v1
+```
+
+`stdio` is the default transport for the package command. You can also make it explicit:
+
+```bash
+APPWRITE_ENDPOINT=http://localhost:9501/v1 \
+APPWRITE_PROJECT_ID=<YOUR_PROJECT_ID> \
+APPWRITE_API_KEY=<YOUR_API_KEY> \
+uvx mcp-server-appwrite --transport stdio
+```
+
+The server validates the endpoint, project ID, API key, and at least one supported service during startup. If credentials or scopes are wrong, the MCP server fails before accepting tool calls.
+
+## How Cloud authentication works
 
 The MCP server validates the bearer access token on every request and forwards it to the Appwrite REST API, which accepts the OAuth2 access token directly. The flow (handled automatically by MCP-aware clients):
 
@@ -98,7 +138,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ### Run the server
 
-With Docker Compose:
+With Docker Compose, the server runs the hosted HTTP/OAuth transport:
 
 ```bash
 docker compose up --build
@@ -116,7 +156,16 @@ With `uv` directly:
 
 ```bash
 MCP_PUBLIC_URL=http://localhost:8000 APPWRITE_ENDPOINT=https://cloud.appwrite.io/v1 \
-  uv run mcp-server-appwrite
+  uv run mcp-server-appwrite --transport http
+```
+
+For local self-hosted stdio development, run with API-key credentials:
+
+```bash
+APPWRITE_ENDPOINT=http://localhost:9501/v1 \
+APPWRITE_PROJECT_ID=<YOUR_PROJECT_ID> \
+APPWRITE_API_KEY=<YOUR_API_KEY> \
+uv run mcp-server-appwrite
 ```
 
 ## Testing
@@ -144,6 +193,8 @@ npx @modelcontextprotocol/inspector
 ```
 
 Point it at `https://mcp.appwrite.io/mcp` and complete the OAuth flow when prompted.
+
+For self-hosted stdio debugging, start Inspector in stdio mode and use `uv run mcp-server-appwrite` as the command with the `APPWRITE_*` environment variables above.
 
 ## License
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,7 @@ services:
     environment:
       HOST: 0.0.0.0
       PORT: 8000
+      MCP_TRANSPORT: http
       APPWRITE_ENDPOINT: ${APPWRITE_ENDPOINT:-https://cloud.appwrite.io/v1}
       APPWRITE_PROJECT_ID: ${APPWRITE_PROJECT_ID:-console}
       MCP_PUBLIC_URL: ${MCP_PUBLIC_URL:-http://localhost:8000}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.appwrite/mcp",
   "description": "MCP (Model Context Protocol) server for Appwrite",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "repository": {
     "url": "https://github.com/appwrite/mcp",
     "source": "github"
@@ -11,6 +11,16 @@
     {
       "type": "streamable-http",
       "url": "https://mcp.appwrite.io/mcp"
+    }
+  ],
+  "packages": [
+    {
+      "version": "0.7.0",
+      "registryType": "pypi",
+      "identifier": "mcp-server-appwrite",
+      "transport": {
+        "type": "stdio"
+      }
     }
   ]
 }

--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -119,7 +119,7 @@ async def health_endpoint(request: Request) -> PlainTextResponse:
 def build_app() -> Starlette:
     tools_manager = build_catalog_tools_manager()
     operator = build_operator(tools_manager)
-    server = build_mcp_server(operator)
+    server = build_mcp_server(operator, transport="http")
 
     # Streamable HTTP with SSE responses (the MCP SDK/ecosystem default). Stateless,
     # so each request opens and closes its own short-lived stream — no session to pin.

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -272,7 +272,9 @@ def validate_services(tools_manager: ToolManager) -> None:
     if not tools_manager.services:
         return
 
-    services_by_name = {service.service_name: service for service in tools_manager.services}
+    services_by_name = {
+        service.service_name: service for service in tools_manager.services
+    }
     service = next(
         (
             services_by_name[service_name]
@@ -712,7 +714,9 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
     return server
 
 
-def build_operator(tools_manager: ToolManager, client: Client | None = None) -> Operator:
+def build_operator(
+    tools_manager: ToolManager, client: Client | None = None
+) -> Operator:
     """Wire the operator surface to the per-request execution path. The execution
     callback re-binds each call to a per-request client via `resolve_client` in
     HTTP/OAuth mode. Pass a client for stdio/API-key mode.

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import base64
 import importlib
 import inspect
@@ -18,6 +19,7 @@ from pathlib import Path
 from types import UnionType
 from typing import Any, Union, get_args, get_origin
 
+import mcp.server.stdio
 import mcp.types as types
 from appwrite.client import Client
 from appwrite.enums.browser import Browser
@@ -25,9 +27,10 @@ from appwrite.exception import AppwriteException
 from appwrite.input_file import InputFile
 from appwrite.service import Service as _SdkService
 from dotenv import find_dotenv, load_dotenv
-from mcp.server import Server
+from mcp.server import NotificationOptions, Server
 from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.lowlevel.helper_types import ReadResourceContents
+from mcp.server.models import InitializationOptions
 
 from .docs_search import DocsSearch
 from .operator import Operator
@@ -37,6 +40,19 @@ from .tool_manager import ToolManager
 SERVER_VERSION = "0.7.0"
 
 DEFAULT_ENDPOINT = "https://cloud.appwrite.io/v1"
+DEFAULT_TRANSPORT = "stdio"
+TRANSPORTS = {"stdio", "http"}
+VALIDATION_SERVICE_ORDER = (
+    "tables_db",
+    "users",
+    "teams",
+    "functions",
+    "sites",
+    "storage",
+    "messaging",
+    "locale",
+    "avatars",
+)
 
 # Service modules in the Appwrite SDK to skip (none by default — every service the
 # installed SDK ships is exposed). Add a module name here to hide a service.
@@ -83,8 +99,22 @@ def _log_startup(message: str) -> None:
     print(f"[appwrite-mcp] {message}", file=sys.stderr, flush=True)
 
 
-def parse_args():
+def _transport_arg(value: str) -> str:
+    if value not in TRANSPORTS:
+        raise argparse.ArgumentTypeError(
+            f"invalid choice: {value!r} (choose from 'http', 'stdio')"
+        )
+    return value
+
+
+def parse_args(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(description="Appwrite MCP Server")
+    parser.add_argument(
+        "--transport",
+        type=_transport_arg,
+        default=os.getenv("MCP_TRANSPORT", DEFAULT_TRANSPORT),
+        help="MCP transport to serve (default $MCP_TRANSPORT or stdio).",
+    )
     parser.add_argument(
         "--host",
         default=os.getenv("HOST", "0.0.0.0"),
@@ -96,17 +126,27 @@ def parse_args():
         default=int(os.getenv("PORT", "8000")),
         help="Bind port for the HTTP server (default $PORT or 8000).",
     )
-    return parser.parse_args()
+    args = parser.parse_args(argv)
+    try:
+        args.transport = _transport_arg(args.transport)
+    except argparse.ArgumentTypeError as exc:
+        parser.error(str(exc))
+    return args
 
 
-def load_appwrite_config() -> AppwriteConfig:
+def load_environment() -> None:
     cwd_dotenv = Path.cwd() / ".env"
     if cwd_dotenv.exists():
         load_dotenv(dotenv_path=cwd_dotenv)
-    else:
-        discovered_dotenv = find_dotenv(usecwd=True)
-        if discovered_dotenv:
-            load_dotenv(dotenv_path=discovered_dotenv)
+        return
+
+    discovered_dotenv = find_dotenv(usecwd=True)
+    if discovered_dotenv:
+        load_dotenv(dotenv_path=discovered_dotenv)
+
+
+def load_appwrite_config() -> AppwriteConfig:
+    load_environment()
 
     project_id = os.getenv("APPWRITE_PROJECT_ID")
     api_key = os.getenv("APPWRITE_API_KEY")
@@ -232,7 +272,18 @@ def validate_services(tools_manager: ToolManager) -> None:
     if not tools_manager.services:
         return
 
-    service = tools_manager.services[0]
+    services_by_name = {service.service_name: service for service in tools_manager.services}
+    service = next(
+        (
+            services_by_name[service_name]
+            for service_name in VALIDATION_SERVICE_ORDER
+            if service_name in services_by_name
+        ),
+        None,
+    )
+    if service is None:
+        return
+
     _log_startup(f"Validating startup access via {service.service_name}")
 
     try:
@@ -600,20 +651,36 @@ def _format_appwrite_error(exc: AppwriteException) -> str:
     return f"Appwrite request failed{detail_text}: {exc}"
 
 
-def build_mcp_server(operator: Operator) -> Server:
-    instructions = (
+def build_instructions(transport: str = "http") -> str:
+    common = (
         "Appwrite workflow: use appwrite_search_tools first, then appwrite_call_tool. "
+        "Mutating hidden tools require confirm_write=true. "
+        "For questions about Appwrite concepts, products, or guides, use "
+        "appwrite_search_docs to search the documentation when available. "
+        "Large results are stored as resources; read the URI returned by the tool."
+    )
+
+    if transport == "stdio":
+        return (
+            "This local Appwrite MCP connection uses the API key, endpoint, and "
+            "project configured in the server environment. Appwrite API calls target "
+            "that configured APPWRITE_PROJECT_ID by default. "
+            f"{common}"
+        )
+
+    return (
         "You authenticate against the Appwrite console, which can list your "
         "organizations and projects but stores no project data itself. Project-scoped "
         "tools (databases, tables, users, storage, functions, messaging, sites) need a "
         "target project: first discover one (search for and call a tool that lists "
         "projects), then pass its id as project_id to appwrite_call_tool. "
         "Organization-scoped console tools (e.g. creating a project) need organization_id. "
-        "Mutating hidden tools require confirm_write=true. "
-        "For questions about Appwrite concepts, products, or guides, use "
-        "appwrite_search_docs to search the documentation (no project_id needed). "
-        "Large results are stored as resources; read the URI returned by the tool."
+        f"{common}"
     )
+
+
+def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
+    instructions = build_instructions(transport)
 
     server = Server("Appwrite MCP Server", instructions=instructions)
 
@@ -645,9 +712,10 @@ def build_mcp_server(operator: Operator) -> Server:
     return server
 
 
-def build_operator(tools_manager: ToolManager) -> Operator:
+def build_operator(tools_manager: ToolManager, client: Client | None = None) -> Operator:
     """Wire the operator surface to the per-request execution path. The execution
-    callback re-binds each call to a per-request client via `resolve_client`.
+    callback re-binds each call to a per-request client via `resolve_client` in
+    HTTP/OAuth mode. Pass a client for stdio/API-key mode.
 
     The docs-search tool is wired in only when its committed index and an
     OPENAI_API_KEY are both available; otherwise the server boots without it."""
@@ -666,6 +734,7 @@ def build_operator(tools_manager: ToolManager) -> Operator:
             tools_manager,
             tool_name,
             tool_arguments,
+            client=client,
             target_project=target_project,
             organization_id=organization_id,
         ),
@@ -679,20 +748,46 @@ def build_catalog_tools_manager() -> ToolManager:
     return register_services(build_introspection_client())
 
 
-def main():
-    """Entry point: serve the Streamable-HTTP + OAuth resource server."""
-    # Load .env early so env-driven config (APPWRITE_ENDPOINT, MCP_PUBLIC_URL,
-    # OPENAI_API_KEY for docs search) is available before the app is built. In
-    # production these are injected directly into the environment.
-    cwd_dotenv = Path.cwd() / ".env"
-    if cwd_dotenv.exists():
-        load_dotenv(dotenv_path=cwd_dotenv)
-    else:
-        discovered_dotenv = find_dotenv(usecwd=True)
-        if discovered_dotenv:
-            load_dotenv(dotenv_path=discovered_dotenv)
+async def run_stdio() -> None:
+    """Serve a local stdio MCP using APPWRITE_* API-key configuration."""
+    _log_startup("Loading Appwrite configuration")
+    config = load_appwrite_config()
+    client = build_client(config)
+    _log_startup(f"Using Appwrite endpoint: {config.endpoint}")
+    _log_startup("Registering Appwrite services")
+    tools_manager = register_services(client)
+    _log_startup("Starting Appwrite service validation")
+    validate_services(tools_manager)
+    _log_startup("Building Appwrite operator surface")
+    operator = build_operator(tools_manager, client=client)
+    server = build_mcp_server(operator, transport="stdio")
 
+    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+        _log_startup("MCP transport: stdio")
+        _log_startup("Appwrite MCP server ready")
+        await server.run(
+            read_stream,
+            write_stream,
+            InitializationOptions(
+                server_name="appwrite",
+                server_version=SERVER_VERSION,
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
+
+
+def main():
+    """Entry point: stdio by default, or Streamable HTTP when requested."""
+    load_environment()
     args = parse_args()
+
+    if args.transport == "stdio":
+        asyncio.run(run_stdio())
+        return 0
+
     from .http_app import run_http
 
     run_http(host=args.host, port=args.port)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -17,6 +17,8 @@ from mcp_server_appwrite.server import (
     _prepare_arguments,
     _validate_service,
     build_client,
+    build_instructions,
+    build_operator,
     parse_args,
     register_services,
     validate_services,
@@ -25,6 +27,42 @@ from mcp_server_appwrite.tool_manager import ToolManager
 
 
 class ServerHelperTests(unittest.TestCase):
+    def test_parse_args_defaults_to_stdio(self):
+        with patch.dict(os.environ, {}, clear=True):
+            args = parse_args([])
+
+        self.assertEqual(args.transport, "stdio")
+        self.assertEqual(args.host, "0.0.0.0")
+        self.assertEqual(args.port, 8000)
+
+    def test_parse_args_accepts_env_transport(self):
+        with patch.dict(os.environ, {"MCP_TRANSPORT": "http", "PORT": "9000"}):
+            args = parse_args([])
+
+        self.assertEqual(args.transport, "http")
+        self.assertEqual(args.port, 9000)
+
+    def test_parse_args_accepts_explicit_transport(self):
+        with patch.dict(os.environ, {"MCP_TRANSPORT": "http"}):
+            args = parse_args(["--transport", "stdio", "--host", "127.0.0.1"])
+
+        self.assertEqual(args.transport, "stdio")
+        self.assertEqual(args.host, "127.0.0.1")
+
+    def test_parse_args_rejects_invalid_env_transport(self):
+        with patch.dict(os.environ, {"MCP_TRANSPORT": "websocket"}):
+            with self.assertRaises(SystemExit):
+                parse_args([])
+
+    def test_build_instructions_are_transport_specific(self):
+        stdio = build_instructions("stdio")
+        http = build_instructions("http")
+
+        self.assertIn("APPWRITE_PROJECT_ID", stdio)
+        self.assertNotIn("Appwrite console", stdio)
+        self.assertIn("Appwrite console", http)
+        self.assertIn("project_id", http)
+
     def test_coerce_input_file_from_path(self):
         with tempfile.NamedTemporaryFile(suffix=".txt") as handle:
             coerced = _coerce_argument("file", handle.name, InputFile)
@@ -257,6 +295,80 @@ class ServerHelperTests(unittest.TestCase):
         ]
 
         validate_services(manager)
+
+    def test_validate_services_skips_unprobed_services(self):
+        class SuccessfulSdkService:
+            def list(self):
+                return {"total": 0}
+
+        manager = ToolManager()
+        manager.services = [
+            type(
+                "UnprobedService",
+                (),
+                {
+                    "service_name": "account",
+                    "service": object(),
+                },
+            )(),
+            type(
+                "StubService",
+                (),
+                {
+                    "service_name": "users",
+                    "service": SuccessfulSdkService(),
+                },
+            )(),
+        ]
+
+        validate_services(manager)
+
+    def test_build_operator_uses_explicit_stdio_client(self):
+        tool = types.Tool(
+            name="users_list",
+            description="List users.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": False,
+            },
+        )
+        manager = ToolManager()
+        manager.tools_registry = {
+            "users_list": {
+                "definition": tool,
+                "service_name": "users",
+                "method_name": "list",
+                "parameter_types": {},
+            }
+        }
+        client = object()
+        seen = {}
+
+        def fake_execute(
+            tools_manager,
+            tool_name,
+            tool_arguments,
+            client=None,
+            target_project=None,
+            organization_id=None,
+        ):
+            seen["client"] = client
+            seen["target_project"] = target_project
+            seen["organization_id"] = organization_id
+            return [types.TextContent(type="text", text="ok")]
+
+        with patch("mcp_server_appwrite.server.execute_registered_tool", fake_execute):
+            operator = build_operator(manager, client=client)
+            result = operator.execute_public_tool(
+                "appwrite_call_tool",
+                {"tool_name": "users_list", "project_id": "ignored"},
+            )
+
+        self.assertEqual(result[0].text, "ok")
+        self.assertIs(seen["client"], client)
+        self.assertEqual(seen["target_project"], "ignored")
 
     def test_validate_services_logs_progress(self):
         class SuccessfulSdkService:


### PR DESCRIPTION
## Summary

- restore local `stdio` transport as the default package entrypoint for self-hosted Appwrite users
- keep hosted Cloud deployments on Streamable HTTP/OAuth via explicit `--transport http`
- document Cloud vs self-hosted setup paths and add unit coverage for transport selection and stdio API-key binding

## Testing

- `uv run ruff check .`
- `uv run python -m unittest discover -s tests/unit -q`
- `uv run --extra integration python -m unittest discover -s tests/integration -v` (live tests skipped because no Appwrite project/key env vars were available)
- manual smoke: stdio missing credentials fail fast
- manual smoke: stdio bad credentials against `http://localhost:9501/v1` fail during startup validation with an Appwrite project error
- manual smoke: HTTP mode `/healthz` returns `200`, unauthenticated `/mcp` returns the OAuth `401` challenge

## Notes

- No self-hosted Appwrite code changes are required.
- No related issue number found, so this PR does not include a `Fixes #...` reference.
