### PR TITLE
Hide health checks and publish Docker Hub images

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,6 +15,7 @@ env:
   DECLARATIVE_OWNER: appwrite-labs
   DECLARATIVE_REPOSITORY: assets-applications
   REGISTRY_GITHUB: ghcr.io
+  REGISTRY_DOCKERHUB: docker.io
   IMAGE_NAME: appwrite/mcp
   TAG: ${{ github.event.release.tag_name || github.sha }}
 
@@ -32,12 +33,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY_DOCKERHUB }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY_GITHUB }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
+          tags: |
+            ${{ env.REGISTRY_GITHUB }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
+            ${{ env.REGISTRY_DOCKERHUB }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
 
   deploy:
     needs: build

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   ENVIRONMENT: production
   PROJECT: mcp

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -16,6 +16,7 @@ env:
   DECLARATIVE_OWNER: appwrite-labs
   DECLARATIVE_REPOSITORY: assets-applications
   REGISTRY_GITHUB: ghcr.io
+  REGISTRY_DOCKERHUB: docker.io
   IMAGE_NAME: appwrite/mcp
   TAG: ${{ github.sha }}
 
@@ -33,12 +34,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY_DOCKERHUB }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY_GITHUB }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
+          tags: |
+            ${{ env.REGISTRY_GITHUB }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
+            ${{ env.REGISTRY_DOCKERHUB }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
 
   deploy:
     needs: build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   ENVIRONMENT: staging
   PROJECT: mcp

--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -15,7 +15,9 @@ validated token is reachable from tool handlers via ``get_access_token()``.
 from __future__ import annotations
 
 import contextlib
+import copy
 import json
+import logging
 import sys
 
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
@@ -47,6 +49,19 @@ _CORS_HEADERS = {
     "Access-Control-Allow-Headers": "Authorization, Content-Type, Mcp-Session-Id, Mcp-Protocol-Version",
     "Access-Control-Expose-Headers": "Mcp-Session-Id, WWW-Authenticate",
 }
+
+
+class HealthzAccessLogFilter(logging.Filter):
+    """Drop noisy load-balancer health probes from uvicorn access logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if isinstance(args, tuple) and len(args) >= 3:
+            method = args[1]
+            path = str(args[2]).split("?", 1)[0]
+            return not (method == "GET" and path == "/healthz")
+
+        return "GET /healthz HTTP/" not in record.getMessage()
 
 
 def _log(message: str) -> None:
@@ -166,7 +181,14 @@ def build_app() -> Starlette:
 
 def run_http(*, host: str = "0.0.0.0", port: int = 8000) -> None:
     import uvicorn
+    from uvicorn.config import LOGGING_CONFIG
 
     app = build_app()
+    log_config = copy.deepcopy(LOGGING_CONFIG)
+    log_config.setdefault("filters", {})["hide_healthz"] = {
+        "()": "mcp_server_appwrite.http_app.HealthzAccessLogFilter"
+    }
+    log_config["handlers"]["access"]["filters"] = ["hide_healthz"]
+
     _log(f"Serving on http://{host}:{port}  (resource path: /mcp)")
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(app, host=host, port=port, log_config=log_config)

--- a/tests/unit/test_http_app.py
+++ b/tests/unit/test_http_app.py
@@ -1,0 +1,41 @@
+import logging
+import unittest
+
+from mcp_server_appwrite.http_app import HealthzAccessLogFilter
+
+
+class HealthzAccessLogFilterTests(unittest.TestCase):
+    def setUp(self):
+        self.filter = HealthzAccessLogFilter()
+
+    def _record(self, args):
+        return logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='%s - "%s %s HTTP/%s" %d',
+            args=args,
+            exc_info=None,
+        )
+
+    def test_filters_healthz_access_logs(self):
+        record = self._record(("127.0.0.1:12345", "GET", "/healthz", "1.1", 200))
+
+        self.assertFalse(self.filter.filter(record))
+
+    def test_filters_healthz_access_logs_with_query_string(self):
+        record = self._record(
+            ("127.0.0.1:12345", "GET", "/healthz?ready=1", "1.1", 200)
+        )
+
+        self.assertFalse(self.filter.filter(record))
+
+    def test_keeps_non_healthz_access_logs(self):
+        record = self._record(("127.0.0.1:12345", "GET", "/mcp", "1.1", 401))
+
+        self.assertTrue(self.filter.filter(record))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Hide noisy `GET /healthz` uvicorn access logs while keeping other access logs visible.
- Publish staging and production deployment images to both GHCR and Docker Hub using the existing `TAG` value.
- Keep the assets repo update scoped to `.mcp.image.tag`, matching appwrite-labs/assets-applications#23 where the repository is switched to Docker Hub (`appwrite/mcp`).

## Testing

- `uv run --group dev ruff check src tests`
- `uv run --group dev black --check src tests`
- `uv run python -m unittest discover -s tests/unit -q`
- Smoke-tested HTTP server: `/healthz` returns 200 without access log noise; `/mcp` still logs the 401 request.
- Parsed `.github/workflows/production.yml` and `.github/workflows/staging.yml` as YAML.
