### PR TITLE
ci: support workflow_dispatch, pin step versions, drop push retries

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -21,31 +21,31 @@ env:
   REGISTRY_GITHUB: ghcr.io
   REGISTRY_DOCKERHUB: docker.io
   IMAGE_NAME: appwrite/mcp
-  TAG: ${{ github.event.release.tag_name }}
+  TAG: ${{ github.event.release.tag_name || github.sha }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY_GITHUB }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY_DOCKERHUB }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Get token for ${{ env.DECLARATIVE_REPOSITORY }}
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.DECLARATIVE_DEPLOYMENT_GITHUB_APP_ID }}
           private-key: ${{ secrets.DECLARATIVE_DEPLOYMENT_GITHUB_APP_PRIVATE_KEY }}
@@ -70,7 +70,7 @@ jobs:
           repositories: ${{ env.DECLARATIVE_REPOSITORY }}
 
       - name: Checkout ${{ env.DECLARATIVE_REPOSITORY }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ env.DECLARATIVE_OWNER }}/${{ env.DECLARATIVE_REPOSITORY }}
           token: ${{ steps.app-token.outputs.token }}
@@ -88,13 +88,4 @@ jobs:
             exit 0
           fi
           git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
-          for attempt in 1 2 3 4 5; do
-            if git push; then
-              echo "Pushed on attempt $attempt"
-              exit 0
-            fi
-            echo "Push rejected (attempt $attempt), rebasing onto remote and retrying..."
-            git pull --rebase
-          done
-          echo "Failed to push after 5 attempts"
-          exit 1
+          git push

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -29,24 +29,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY_GITHUB }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY_DOCKERHUB }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Get token for ${{ env.DECLARATIVE_REPOSITORY }}
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.DECLARATIVE_DEPLOYMENT_GITHUB_APP_ID }}
           private-key: ${{ secrets.DECLARATIVE_DEPLOYMENT_GITHUB_APP_PRIVATE_KEY }}
@@ -71,7 +71,7 @@ jobs:
           repositories: ${{ env.DECLARATIVE_REPOSITORY }}
 
       - name: Checkout ${{ env.DECLARATIVE_REPOSITORY }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ env.DECLARATIVE_OWNER }}/${{ env.DECLARATIVE_REPOSITORY }}
           token: ${{ steps.app-token.outputs.token }}
@@ -89,13 +89,4 @@ jobs:
             exit 0
           fi
           git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
-          for attempt in 1 2 3 4 5; do
-            if git push; then
-              echo "Pushed on attempt $attempt"
-              exit 0
-            fi
-            echo "Push rejected (attempt $attempt), rebasing onto remote and retrying..."
-            git pull --rebase
-          done
-          echo "Failed to push after 5 attempts"
-          exit 1
+          git push


### PR DESCRIPTION
## Summary
- Fall back to `github.sha` for the production image tag (`${{ github.event.release.tag_name || github.sha }}`) so manual `workflow_dispatch` runs — which carry no release payload — still produce a valid tag. Staging already used `github.sha`, so it's unchanged.
- Tighten the deploy workflows' action pins to exact-semver comments matching the `ci.yml`/`publish.yml` convention (checkout v6.0.3, login-action v3.7.0, build-push-action v6.19.2, create-github-app-token v2.2.2). SHAs are unchanged — only the comments are now precise.
- Remove the 5-attempt push/rebase retry loop in both deploy workflows. The shared `concurrency.group: declarative-deploy` (`cancel-in-progress: false`) already serializes deploys, making the retry redundant; a rejected push now fails fast.

## Notes
Affects `staging.yml` and `production.yml` only. Both validate as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)