### PR TITLE
feat: add OpenTelemetry metrics for the hosted MCP server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,38 @@ Source lives in `src/mcp_server_appwrite/`:
 | `operator.py` | The compact "operator" surface — `appwrite_search_tools`, `appwrite_call_tool`, result/resource storage, write confirmation. |
 | `context.py` | `appwrite_get_context` — workspace summary (project, services, account/org for OAuth). |
 | `docs_search.py` | In-process semantic docs search (`appwrite_search_docs`) over a prebuilt index. |
+| `telemetry.py` | OpenTelemetry metrics layer (OTLP/HTTP). No-op unless an OTLP endpoint is configured and the transport is `http`. |
 | `data/` | Committed docs index artifact (`docs_index.npz`, `docs_index_meta.json`), shipped in the wheel/image. |
 
 `scripts/build_docs_index.py` rebuilds the docs index (requires `OPENAI_API_KEY`).
+
+### Telemetry (metrics)
+
+The hosted HTTP server emits OpenTelemetry metrics over OTLP/HTTP to the shared
+Appwrite observability stack (OpenTelemetry Collector → Prometheus/Mimir → Grafana
+at `telemetry.appwrite.systems`), mirroring the `utopia-php/telemetry` pattern used
+by the PHP services. All instrumentation lives in `telemetry.py` and is wired in at
+the operator/handler/auth boundaries.
+
+* **Hosted-only & no-op by default.** Telemetry is enabled only when the transport
+  is `http` *and* an OTLP endpoint is set. The self-hosted `stdio` transport never
+  emits, and an unconfigured hosted server is a silent no-op.
+* **Config (env):** `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS`
+  (standard OTel), or the cloud-style aliases `_APP_TELEMETRY_OTLP_ENDPOINT` /
+  `_APP_TELEMETRY_OTLP_HEADERS`. Set `OTEL_RESOURCE_ATTRIBUTES` to carry
+  `deployment.environment.name` / `deployment.region.name` / `deployment.cluster.name`
+  so the metrics match the fleet-wide Grafana dashboard variable filters
+  (`deployment_environment_name`, etc.).
+* **Metrics** are prefixed `mcp.` (e.g. `mcp.requests`, `mcp.appwrite.calls`,
+  `mcp.initializations`, `mcp.auth.validations`). User ids (`sub`) are never used as
+  labels — distinct-user/-client counts are derived in-process and exposed only as
+  the aggregate gauges `mcp.users.active` / `mcp.clients.active`.
+* **Dashboards** live in the separate `dashboards` repo under `MCP/`
+  (`overview.json`, `adoption.json`).
+* **Local check:** run an OTel Collector on `:4318` with a debug exporter, start the
+  server with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 ... --transport http`,
+  and confirm metrics appear. Unit tests use an in-memory reader
+  (`tests/unit/test_telemetry.py`) — no collector required.
 
 ### Tool surface (key design point)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,15 +46,12 @@ the operator/handler/auth boundaries.
 * **Hosted-only & no-op by default.** Telemetry is enabled only when the transport
   is `http` *and* an OTLP endpoint is set. The self-hosted `stdio` transport never
   emits, and an unconfigured hosted server is a silent no-op.
-* **Config (env):** `OTEL_EXPORTER_OTLP_ENDPOINT` enables export. Headers come from
-  `OTEL_EXPORTER_OTLP_HEADERS`, or — if that is unset — are assembled from
-  `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` (the shared `telemetry-auth`
-  Cloudflare Access secret) into `CF-Access-Client-Id=…,CF-Access-Client-Secret=…`,
-  so the deployment passes those two vars directly and reuses the existing secret.
-  Set `OTEL_RESOURCE_ATTRIBUTES` to carry
-  `deployment.environment.name` / `deployment.region.name` / `deployment.cluster.name`
-  so the metrics match the fleet-wide Grafana dashboard variable filters
-  (`deployment_environment_name`, etc.).
+* **Config (env):** `OTEL_EXPORTER_OTLP_ENDPOINT` enables export and points at the
+  in-cluster Alloy collector (`http://alloy.telemetry.svc.cluster.local:4318`). Alloy
+  authenticates and forwards upstream and **upserts** the `deployment.environment.name`
+  / `deployment.region.name` / `deployment.cluster.name` resource attributes that the
+  fleet-wide Grafana dashboards filter on — so the app needs no credentials and no
+  `OTEL_RESOURCE_ATTRIBUTES`.
 * **Metrics** are prefixed `mcp.` (e.g. `mcp.requests`, `mcp.appwrite.calls`,
   `mcp.initializations`, `mcp.auth.validations`). User ids (`sub`) are never used as
   labels — distinct-user/-client counts are derived in-process and exposed only as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,12 @@ the operator/handler/auth boundaries.
 * **Hosted-only & no-op by default.** Telemetry is enabled only when the transport
   is `http` *and* an OTLP endpoint is set. The self-hosted `stdio` transport never
   emits, and an unconfigured hosted server is a silent no-op.
-* **Config (env):** `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS`
-  (standard OTel), or the cloud-style aliases `_APP_TELEMETRY_OTLP_ENDPOINT` /
-  `_APP_TELEMETRY_OTLP_HEADERS`. Set `OTEL_RESOURCE_ATTRIBUTES` to carry
+* **Config (env):** `OTEL_EXPORTER_OTLP_ENDPOINT` enables export. Headers come from
+  `OTEL_EXPORTER_OTLP_HEADERS`, or — if that is unset — are assembled from
+  `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` (the shared `telemetry-auth`
+  Cloudflare Access secret) into `CF-Access-Client-Id=…,CF-Access-Client-Secret=…`,
+  so the deployment passes those two vars directly and reuses the existing secret.
+  Set `OTEL_RESOURCE_ATTRIBUTES` to carry
   `deployment.environment.name` / `deployment.region.name` / `deployment.cluster.name`
   so the metrics match the fleet-wide Grafana dashboard variable filters
   (`deployment_environment_name`, etc.).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,31 +37,11 @@ Source lives in `src/mcp_server_appwrite/`:
 
 ### Telemetry (metrics)
 
-The hosted HTTP server emits OpenTelemetry metrics over OTLP/HTTP to the shared
-Appwrite observability stack (OpenTelemetry Collector → Prometheus/Mimir → Grafana
-at `telemetry.appwrite.systems`), mirroring the `utopia-php/telemetry` pattern used
-by the PHP services. All instrumentation lives in `telemetry.py` and is wired in at
-the operator/handler/auth boundaries.
-
-* **Hosted-only & no-op by default.** Telemetry is enabled only when the transport
-  is `http` *and* an OTLP endpoint is set. The self-hosted `stdio` transport never
-  emits, and an unconfigured hosted server is a silent no-op.
-* **Config (env):** `OTEL_EXPORTER_OTLP_ENDPOINT` enables export and points at the
-  in-cluster Alloy collector (`http://alloy.telemetry.svc.cluster.local:4318`). Alloy
-  authenticates and forwards upstream and **upserts** the `deployment.environment.name`
-  / `deployment.region.name` / `deployment.cluster.name` resource attributes that the
-  fleet-wide Grafana dashboards filter on — so the app needs no credentials and no
-  `OTEL_RESOURCE_ATTRIBUTES`.
-* **Metrics** are prefixed `mcp.` (e.g. `mcp.requests`, `mcp.appwrite.calls`,
-  `mcp.initializations`, `mcp.auth.validations`). User ids (`sub`) are never used as
-  labels — distinct-user/-client counts are derived in-process and exposed only as
-  the aggregate gauges `mcp.users.active` / `mcp.clients.active`.
-* **Dashboards** live in the separate `dashboards` repo under `MCP/`
-  (`overview.json`, `adoption.json`).
-* **Local check:** run an OTel Collector on `:4318` with a debug exporter, start the
-  server with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 ... --transport http`,
-  and confirm metrics appear. Unit tests use an in-memory reader
-  (`tests/unit/test_telemetry.py`) — no collector required.
+`telemetry.py` emits OpenTelemetry metrics (prefixed `mcp.`) over OTLP/HTTP. It is a
+no-op unless the transport is `http` and `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so
+`stdio` and unconfigured servers stay silent. In the cluster that endpoint is the
+Alloy collector, which adds the `deployment.*` labels and forwards upstream — the app
+needs no credentials. Dashboards live in the `dashboards` repo under `MCP/`.
 
 ### Tool surface (key design point)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,10 +15,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       DOCS_SEARCH_MIN_SCORE: ${DOCS_SEARCH_MIN_SCORE:-0.25}
       DOCS_SEARCH_LIMIT: ${DOCS_SEARCH_LIMIT:-5}
-      # OpenTelemetry metrics (hosted HTTP transport only). Unset endpoint = no-op.
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
-      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
-      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-}
     healthcheck:
       test:
         [

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,10 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       DOCS_SEARCH_MIN_SCORE: ${DOCS_SEARCH_MIN_SCORE:-0.25}
       DOCS_SEARCH_LIMIT: ${DOCS_SEARCH_LIMIT:-5}
+      # OpenTelemetry metrics (hosted HTTP transport only). Unset endpoint = no-op.
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
+      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-}
     healthcheck:
       test:
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "pyjwt[crypto]>=2.9.0",
     "numpy>=2.0",
     "openai>=1.40",
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-http>=1.27",
 ]
 
 [project.optional-dependencies]

--- a/src/mcp_server_appwrite/auth.py
+++ b/src/mcp_server_appwrite/auth.py
@@ -25,6 +25,8 @@ import jwt
 from jwt import PyJWKClient
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 
+from . import telemetry
+
 DEFAULT_ENDPOINT = "https://cloud.appwrite.io/v1"
 DEFAULT_PROJECT_ID = "console"
 
@@ -198,6 +200,7 @@ class AppwriteTokenVerifier(TokenVerifier):
         try:
             unverified = jwt.decode(token, options={"verify_signature": False})
         except jwt.PyJWTError:
+            telemetry.record_auth(outcome="rejected", reason="malformed")
             return None
 
         issuer = unverified.get("iss")
@@ -205,6 +208,7 @@ class AppwriteTokenVerifier(TokenVerifier):
             metadata = authorization_server_metadata_sync()
         except Exception as exc:
             _log(f"Rejecting token: authorization server discovery failed ({exc}).")
+            telemetry.record_auth(outcome="rejected", reason="discovery_failed")
             return None
 
         expected_issuer = metadata["issuer"]
@@ -213,17 +217,20 @@ class AppwriteTokenVerifier(TokenVerifier):
                 f"Rejecting token: issuer {issuer!r} does not match discovered "
                 f"issuer {expected_issuer!r}."
             )
+            telemetry.record_auth(outcome="rejected", reason="issuer_mismatch")
             return None
 
         project_id = project_id_from_issuer(issuer)
         if not project_id:
             _log("Rejecting token: issuer is not an Appwrite OAuth issuer.")
+            telemetry.record_auth(outcome="rejected", reason="issuer_mismatch")
             return None
         if project_id != configured_project_id():
             _log(
                 f"Rejecting token: issuer project {project_id!r} is not the served "
                 f"project {configured_project_id()!r}."
             )
+            telemetry.record_auth(outcome="rejected", reason="project_mismatch")
             return None
 
         try:
@@ -238,10 +245,12 @@ class AppwriteTokenVerifier(TokenVerifier):
             )
         except jwt.PyJWTError as exc:
             _log(f"Rejecting token: verification failed ({exc}).")
+            telemetry.record_auth(outcome="rejected", reason="signature")
             return None
 
         expected_resource = canonical_resource()
         if not self._audience_ok(claims.get("aud"), expected_resource):
+            telemetry.record_auth(outcome="rejected", reason="audience")
             return None
 
         scope_claim = claims.get("scope") or claims.get("scp") or ""
@@ -276,9 +285,18 @@ class AppwriteTokenVerifier(TokenVerifier):
         return False
 
     async def verify_token(self, token: str) -> AccessToken | None:
+        start = time.monotonic()
         access_token = await anyio.to_thread.run_sync(self._verify_sync, token)
+        duration = time.monotonic() - start
         if access_token is None:
+            # The specific rejection reason was already counted in _verify_sync;
+            # here we only attach the duration to the rejected outcome.
+            telemetry.record_auth(outcome="rejected", duration_s=duration, count=False)
             return None
         if access_token.expires_at and access_token.expires_at < int(time.time()):
+            telemetry.record_auth(
+                outcome="rejected", reason="expired", duration_s=duration
+            )
             return None
+        telemetry.record_auth(outcome="success", duration_s=duration)
         return access_token

--- a/src/mcp_server_appwrite/docs_search.py
+++ b/src/mcp_server_appwrite/docs_search.py
@@ -93,7 +93,6 @@ class DocsSearch:
         self._vectors = None  # np.ndarray [N, D], L2-normalized
         self._chunk_page = None  # np.ndarray [N] int, index into self._pages
         self._pages: list[dict[str, Any]] = []
-        self._last_embedding_duration_s: float | None = None
         self._index_loaded = self._load_index()
 
     @property
@@ -159,12 +158,11 @@ class DocsSearch:
             )
 
         limit = _clamp_limit(arguments.get("limit"), self._default_limit)
-        self._last_embedding_duration_s = None
-        results = self._rank(query, limit)
+        results, embedding_duration_s = self._rank(query, limit)
         telemetry.record_search_docs(
             outcome="success",
             match_count=len(results),
-            embedding_duration_s=self._last_embedding_duration_s,
+            embedding_duration_s=embedding_duration_s,
         )
 
         if not results:
@@ -183,15 +181,16 @@ class DocsSearch:
             )
         ]
 
-    def _rank(self, query: str, limit: int) -> list[dict[str, Any]]:
+    def _rank(self, query: str, limit: int) -> tuple[list[dict[str, Any]], float]:
+        """Return the ranked pages and the embedding call's duration in seconds."""
         import numpy as np
 
         embed_start = time.monotonic()
         embedding = np.asarray(self._embedder(query), dtype=np.float32)
-        self._last_embedding_duration_s = time.monotonic() - embed_start
+        embedding_duration_s = time.monotonic() - embed_start
         norm = float(np.linalg.norm(embedding))
         if norm == 0.0:
-            return []
+            return [], embedding_duration_s
         embedding /= norm
 
         scores = self._vectors @ embedding  # cosine similarity (both normalized)
@@ -219,4 +218,4 @@ class DocsSearch:
                     "content": page.get("content", ""),
                 }
             )
-        return results
+        return results, embedding_duration_s

--- a/src/mcp_server_appwrite/docs_search.py
+++ b/src/mcp_server_appwrite/docs_search.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 from typing import Any, Callable
 
 import mcp.types as types
+
+from . import telemetry
 
 ToolContent = types.TextContent | types.ImageContent | types.EmbeddedResource
 
@@ -90,6 +93,7 @@ class DocsSearch:
         self._vectors = None  # np.ndarray [N, D], L2-normalized
         self._chunk_page = None  # np.ndarray [N] int, index into self._pages
         self._pages: list[dict[str, Any]] = []
+        self._last_embedding_duration_s: float | None = None
         self._index_loaded = self._load_index()
 
     @property
@@ -155,7 +159,13 @@ class DocsSearch:
             )
 
         limit = _clamp_limit(arguments.get("limit"), self._default_limit)
+        self._last_embedding_duration_s = None
         results = self._rank(query, limit)
+        telemetry.record_search_docs(
+            outcome="success",
+            match_count=len(results),
+            embedding_duration_s=self._last_embedding_duration_s,
+        )
 
         if not results:
             return [
@@ -176,7 +186,9 @@ class DocsSearch:
     def _rank(self, query: str, limit: int) -> list[dict[str, Any]]:
         import numpy as np
 
+        embed_start = time.monotonic()
         embedding = np.asarray(self._embedder(query), dtype=np.float32)
+        self._last_embedding_duration_s = time.monotonic() - embed_start
         norm = float(np.linalg.norm(embedding))
         if norm == 0.0:
             return []

--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -31,6 +31,7 @@ from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Route
 from starlette.types import Receive, Scope, Send
 
+from . import telemetry
 from .auth import (
     AppwriteTokenVerifier,
     protected_resource_metadata,
@@ -111,6 +112,11 @@ class RequireBearer:
 
         user = scope.get("user")
         if not isinstance(user, AuthenticatedUser):
+            # A presented-but-invalid token was already counted (with its specific
+            # reason) by the token verifier. Only count the no-token case here so we
+            # don't double-count rejections.
+            if not _has_authorization_header(scope):
+                telemetry.record_auth(outcome="rejected", reason="missing")
             await _send_401(send)
             return
 
@@ -120,6 +126,13 @@ class RequireBearer:
         headers = [(k.lower().encode(), v.encode()) for k, v in _CORS_HEADERS.items()]
         await send({"type": "http.response.start", "status": 204, "headers": headers})
         await send({"type": "http.response.body", "body": b""})
+
+
+def _has_authorization_header(scope: Scope) -> bool:
+    for name, _value in scope.get("headers", []):
+        if name == b"authorization":
+            return True
+    return False
 
 
 async def protected_resource_metadata_endpoint(request: Request) -> JSONResponse:
@@ -132,6 +145,7 @@ async def health_endpoint(request: Request) -> PlainTextResponse:
 
 
 def build_app() -> Starlette:
+    telemetry.init_telemetry("http", SERVER_VERSION)
     tools_manager = build_catalog_tools_manager()
     operator = build_operator(tools_manager)
     server = build_mcp_server(operator, transport="http")

--- a/src/mcp_server_appwrite/operator.py
+++ b/src/mcp_server_appwrite/operator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -11,6 +12,7 @@ from uuid import uuid4
 import mcp.types as types
 from mcp.server.lowlevel.helper_types import ReadResourceContents
 
+from . import telemetry
 from .docs_search import DocsSearch
 from .tool_manager import ToolManager
 
@@ -254,6 +256,19 @@ class Operator:
     def execute_public_tool(
         self, name: str, arguments: dict[str, Any] | None
     ) -> list[ToolContent]:
+        start = time.monotonic()
+        outcome = "success"
+        try:
+            return self._dispatch_public_tool(name, arguments)
+        except Exception:
+            outcome = "error"
+            raise
+        finally:
+            telemetry.record_tool_call(name, outcome, time.monotonic() - start)
+
+    def _dispatch_public_tool(
+        self, name: str, arguments: dict[str, Any] | None
+    ) -> list[ToolContent]:
         if name == "appwrite_get_context":
             return self._get_context(arguments or {})
         if name == "appwrite_search_tools":
@@ -269,6 +284,15 @@ class Operator:
         if self._context_provider is None:
             raise RuntimeError("Appwrite context provider is not configured.")
         context = self._context_provider(arguments)
+        mode = "unknown"
+        if isinstance(context, dict):
+            connection = context.get("connection")
+            if isinstance(connection, dict):
+                mode = str(connection.get("mode", "unknown"))
+        include_services = bool(
+            arguments.get("include_services", arguments.get("includeServices", True))
+        )
+        telemetry.record_context_request(mode=mode, include_services=include_services)
         return [types.TextContent(type="text", text=json.dumps(context, indent=2))]
 
     def list_resources(self) -> list[types.Resource]:
@@ -381,6 +405,9 @@ class Operator:
             include_mutating=include_mutating,
             limit=_normalize_limit(arguments.get("limit"), self._search_limit),
         )
+        telemetry.record_search_tools(
+            include_mutating=include_mutating, match_count=len(matches)
+        )
 
         lines: list[str] = []
         if not matches:
@@ -426,10 +453,13 @@ class Operator:
         confirm_write = bool(
             raw_arguments.get("confirm_write", raw_arguments.get("confirmWrite", False))
         )
-        if entry.classification != "read" and not confirm_write:
-            raise RuntimeError(
-                f"Tool {tool_name} is {entry.classification}. Re-run appwrite_call_tool with confirm_write=true if you intend to mutate Appwrite state."
-            )
+        if entry.classification != "read":
+            if not confirm_write:
+                telemetry.record_write_confirmation(entry.classification, "blocked")
+                raise RuntimeError(
+                    f"Tool {tool_name} is {entry.classification}. Re-run appwrite_call_tool with confirm_write=true if you intend to mutate Appwrite state."
+                )
+            telemetry.record_write_confirmation(entry.classification, "confirmed")
 
         project_id = raw_arguments.get("project_id", raw_arguments.get("projectId"))
         organization_id = raw_arguments.get(
@@ -454,6 +484,7 @@ class Operator:
             stored_result = self._result_store.save(
                 tool_name, content, _serialize_content(content)
             )
+            telemetry.record_result_stored(tool_name)
             preview = full_text[: self._preview_threshold]
             return [
                 types.TextContent(
@@ -468,6 +499,7 @@ class Operator:
         stored_result = self._result_store.save(
             tool_name, content, _serialize_content(content)
         )
+        telemetry.record_result_stored(tool_name)
         summary = ", ".join(_summarize_content_item(item) for item in content)
         return [
             types.TextContent(

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -13,6 +13,7 @@ import pkgutil
 import re
 import socket
 import sys
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -37,9 +38,10 @@ from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.models import InitializationOptions
 
+from . import telemetry
 from .context import _normalize_sample_limit, get_appwrite_context
 from .docs_search import DocsSearch
-from .operator import Operator
+from .operator import CATALOG_URI, Operator, _parse_tool_name
 from .service import Service
 from .tool_manager import ToolManager
 
@@ -297,18 +299,21 @@ def validate_services(tools_manager: ToolManager) -> None:
     try:
         _validate_service(service)
     except AppwriteException as exc:
+        telemetry.record_startup_validation(service.service_name, "error")
         raise RuntimeError(
             "Appwrite startup validation failed during the minimal startup probe. "
             "Check your endpoint, project ID, API key, and required scopes.\n"
             f"- {service.service_name}: {_format_appwrite_error(exc)}"
         ) from exc
     except Exception as exc:
+        telemetry.record_startup_validation(service.service_name, "error")
         raise RuntimeError(
             "Appwrite startup validation failed during the minimal startup probe. "
             "Check your endpoint, project ID, API key, and required scopes.\n"
             f"- {service.service_name}: {exc}"
         ) from exc
 
+    telemetry.record_startup_validation(service.service_name, "success")
     _log_startup(f"Validated startup access via {service.service_name}")
 
 
@@ -370,17 +375,20 @@ def _validate_fetch_url(url: str) -> None:
     """
     parts = urlsplit(url)
     if parts.scheme not in ("http", "https"):
+        telemetry.record_upload_error("scheme")
         raise ValueError(
             f"Unsupported URL scheme '{parts.scheme}' — only http and https are allowed."
         )
     host = parts.hostname
     if not host:
+        telemetry.record_upload_error("scheme")
         raise ValueError("URL is missing a host.")
 
     port = parts.port or (443 if parts.scheme == "https" else 80)
     try:
         infos = socket.getaddrinfo(host, port)
     except socket.gaierror as exc:
+        telemetry.record_upload_error("dns")
         raise ValueError(f"Could not resolve host '{host}'.") from exc
 
     for info in infos:
@@ -393,6 +401,7 @@ def _validate_fetch_url(url: str) -> None:
             or ip.is_multicast
             or ip.is_unspecified
         ):
+            telemetry.record_upload_error("ssrf")
             raise ValueError(
                 "Refusing to fetch a URL that resolves to a private, loopback, or "
                 "link-local address."
@@ -438,6 +447,7 @@ def _fetch_input_file(url: str, param_name: str) -> InputFile:
                 declared = resp.headers.get("content-length")
                 if declared is not None and declared.isdigit():
                     if int(declared) > _MAX_FETCH_BYTES:
+                        telemetry.record_upload_error("too_large")
                         raise ValueError(
                             f"File at URL for '{param_name}' is too large "
                             f"({declared} bytes); max is {_MAX_FETCH_BYTES} bytes."
@@ -448,6 +458,7 @@ def _fetch_input_file(url: str, param_name: str) -> InputFile:
                 for chunk in resp.iter_bytes():
                     total += len(chunk)
                     if total > _MAX_FETCH_BYTES:
+                        telemetry.record_upload_error("too_large")
                         raise ValueError(
                             f"File at URL for '{param_name}' exceeds the max of "
                             f"{_MAX_FETCH_BYTES} bytes."
@@ -460,10 +471,13 @@ def _fetch_input_file(url: str, param_name: str) -> InputFile:
                 )
                 filename = _derive_filename(resp, url)
     except httpx.HTTPError as exc:
+        reason = "timeout" if isinstance(exc, httpx.TimeoutException) else "http_error"
+        telemetry.record_upload_error(reason)
         raise ValueError(
             f"Failed to fetch file from URL for '{param_name}': {exc}"
         ) from exc
 
+    telemetry.record_upload(source="url", outcome="success", size_bytes=len(data))
     return InputFile.from_bytes(data, filename, mime_type or None)
 
 
@@ -475,26 +489,31 @@ def _coerce_inline_content(value: Mapping, param_name: str) -> InputFile:
         try:
             data = base64.b64decode(content)
         except Exception as exc:
+            telemetry.record_upload_error("decode")
             raise ValueError(f"Invalid base64 content for '{param_name}'.") from exc
     elif encoding == "utf-8":
         data = str(content).encode("utf-8")
     else:
+        telemetry.record_upload_error("encoding")
         raise ValueError(
             f"Invalid encoding for '{param_name}'. Expected 'utf-8' or 'base64'."
         )
 
     if len(data) > _MAX_INLINE_BYTES:
+        telemetry.record_upload_error("too_large")
         raise ValueError(
             f"Inline content for '{param_name}' is too large "
             f"({len(data)} bytes, max {_MAX_INLINE_BYTES}). For larger files pass "
             '{"url": "https://..."} so the server can download it directly.'
         )
 
+    telemetry.record_upload(source="inline", outcome="success", size_bytes=len(data))
     return InputFile.from_bytes(data, str(filename), value.get("mime_type"))
 
 
 def _coerce_path(path: str, param_name: str) -> InputFile:
     if _UPLOAD_TRANSPORT != "stdio":
+        telemetry.record_upload_error("path_unsupported")
         raise ValueError(_HOSTED_PATH_GUIDANCE.format(param=param_name))
     return InputFile.from_path(path)
 
@@ -710,11 +729,39 @@ def execute_registered_tool(
         client = resolve_client(target_project, organization_id)
     bound_method = getattr(service_cls(client), method_name)
 
+    parsed = _parse_tool_name(name)
+    start = time.monotonic()
     try:
         result = bound_method(**prepared_arguments)
     except AppwriteException as exc:
+        telemetry.record_appwrite_call(
+            service=parsed["service_name"],
+            action=parsed["action_verb"],
+            classification=parsed["classification"],
+            outcome="error",
+            duration_s=time.monotonic() - start,
+            error_code=getattr(exc, "code", None),
+            error_type=getattr(exc, "type", None),
+        )
         raise RuntimeError(_format_appwrite_error(exc)) from exc
+    except Exception:
+        telemetry.record_appwrite_call(
+            service=parsed["service_name"],
+            action=parsed["action_verb"],
+            classification=parsed["classification"],
+            outcome="error",
+            duration_s=time.monotonic() - start,
+            error_type="internal",
+        )
+        raise
 
+    telemetry.record_appwrite_call(
+        service=parsed["service_name"],
+        action=parsed["action_verb"],
+        classification=parsed["classification"],
+        outcome="success",
+        duration_s=time.monotonic() - start,
+    )
     return _format_tool_result(name, result, prepared_arguments)
 
 
@@ -859,20 +906,44 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
 
     @server.list_tools()
     async def handle_list_tools() -> list[types.Tool]:
-        return operator.get_public_tools()
+        _emit_initialize(server)
+        start = time.monotonic()
+        try:
+            result = operator.get_public_tools()
+        except Exception:
+            telemetry.record_request("tools/list", "error", time.monotonic() - start)
+            raise
+        telemetry.record_request("tools/list", "success", time.monotonic() - start)
+        return result
 
     @server.call_tool()
     async def handle_call_tool(
         name: str, arguments: dict | None
     ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
-        if operator.has_public_tool(name):
-            return operator.execute_public_tool(name, arguments)
-
-        raise ValueError(f"Tool {name} not found")
+        _emit_initialize(server)
+        start = time.monotonic()
+        try:
+            if not operator.has_public_tool(name):
+                raise ValueError(f"Tool {name} not found")
+            result = operator.execute_public_tool(name, arguments)
+        except Exception:
+            telemetry.record_request("tools/call", "error", time.monotonic() - start)
+            raise
+        telemetry.record_request("tools/call", "success", time.monotonic() - start)
+        return result
 
     @server.list_resources()
     async def handle_list_resources() -> list[types.Resource]:
-        return operator.list_resources()
+        start = time.monotonic()
+        try:
+            result = operator.list_resources()
+        except Exception:
+            telemetry.record_request(
+                "resources/list", "error", time.monotonic() - start
+            )
+            raise
+        telemetry.record_request("resources/list", "success", time.monotonic() - start)
+        return result
 
     @server.list_resource_templates()
     async def handle_list_resource_templates() -> list[types.ResourceTemplate]:
@@ -880,9 +951,55 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
 
     @server.read_resource()
     async def handle_read_resource(uri) -> list[ReadResourceContents]:
-        return operator.read_resource(str(uri))
+        start = time.monotonic()
+        uri_str = str(uri)
+        resource_type = "catalog" if uri_str == CATALOG_URI else "result"
+        telemetry.record_resource_read(resource_type)
+        try:
+            result = operator.read_resource(uri_str)
+        except Exception:
+            telemetry.record_request(
+                "resources/read", "error", time.monotonic() - start
+            )
+            raise
+        telemetry.record_request("resources/read", "success", time.monotonic() - start)
+        return result
 
     return server
+
+
+def _emit_initialize(server: Server) -> None:
+    """Emit an ``mcp.initializations`` event and refresh active-user/client tracking
+    for the current session. Deduped per session in the telemetry layer. Best-effort:
+    any failure to read the request context is swallowed."""
+    try:
+        session = server.request_context.session
+        params = session.client_params
+    except Exception:
+        return
+    if params is None:
+        return
+
+    client_info = getattr(params, "clientInfo", None)
+    oauth_client_id = None
+    subject = None
+    try:
+        access_token = get_access_token()
+        if access_token is not None:
+            claims = access_token.claims or {}
+            oauth_client_id = claims.get("client_id") or claims.get("azp")
+            subject = access_token.subject or claims.get("sub")
+    except Exception:
+        pass
+
+    telemetry.record_initialize(
+        session_id=id(session),
+        client_name=getattr(client_info, "name", None),
+        client_version=getattr(client_info, "version", None),
+        protocol_version=getattr(params, "protocolVersion", None),
+        oauth_client_id=oauth_client_id,
+        subject=subject,
+    )
 
 
 def build_operator(

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -381,7 +381,7 @@ def _validate_fetch_url(url: str) -> None:
         )
     host = parts.hostname
     if not host:
-        telemetry.record_upload_error("scheme")
+        telemetry.record_upload_error("no_host")
         raise ValueError("URL is missing a host.")
 
     port = parts.port or (443 if parts.scheme == "https" else 80)

--- a/src/mcp_server_appwrite/telemetry.py
+++ b/src/mcp_server_appwrite/telemetry.py
@@ -1,0 +1,506 @@
+"""OpenTelemetry metrics for the hosted Appwrite MCP server.
+
+This module mirrors the ``utopia-php/telemetry`` pattern used by the other Appwrite
+services: it exports OpenTelemetry metrics over OTLP/HTTP to an OpenTelemetry
+Collector, which forwards them to the shared Prometheus/Mimir + Grafana stack
+(``telemetry.appwrite.systems``).
+
+Design notes:
+
+* **No-op by default.** Like the PHP ``None``/``NoTelemetry`` adapter, the module
+  emits nothing unless an OTLP endpoint is configured *and* the server runs the
+  hosted ``http`` transport. The self-hosted ``stdio`` transport runs on users'
+  machines and must never phone home, so ``init_telemetry`` is a no-op there.
+* **Exception-safe.** Every ``record_*`` helper swallows its own errors —
+  telemetry must never break a request.
+* **Cardinality-disciplined.** No user id (``sub``), token, raw query text, file
+  name, result id, or IP is ever used as a metric attribute. Distinct-user and
+  distinct-client counts are derived in-process from rolling TTL sets and exposed
+  only as aggregate gauges.
+
+Configuration (env):
+
+* ``OTEL_EXPORTER_OTLP_ENDPOINT`` / ``OTEL_EXPORTER_OTLP_HEADERS`` — standard OTel.
+* ``_APP_TELEMETRY_OTLP_ENDPOINT`` / ``_APP_TELEMETRY_OTLP_HEADERS`` — cloud-style
+  aliases, accepted for parity with the PHP services and existing deploy config.
+* ``OTEL_SERVICE_NAME`` / ``OTEL_RESOURCE_ATTRIBUTES`` — picked up by the SDK to set
+  ``service.name`` and ``deployment.environment`` / ``deployment.region`` etc., so
+  the existing Grafana dashboards' label filters apply unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import threading
+import time
+from typing import Any, Iterable
+
+_ACTIVE_WINDOW_SECONDS = 300.0  # rolling window for "active users/clients" gauges
+
+_enabled = False
+_lock = threading.Lock()
+
+# Metric instruments, populated by init_telemetry when enabled.
+_instruments: dict[str, Any] = {}
+
+# Rolling TTL sets for the active-user/active-client observable gauges. Keys expire
+# after _ACTIVE_WINDOW_SECONDS so the gauges reflect a recent window, not all time.
+_active_users: dict[str, float] = {}
+_active_clients: dict[str, float] = {}  # key: client name -> last-seen monotonic-ish ts
+_active_lock = threading.Lock()
+
+# Dedupe initialize events: one per MCP session object.
+_seen_sessions: set[int] = set()
+
+
+def _log(message: str) -> None:
+    print(f"[appwrite-mcp][telemetry] {message}", file=sys.stderr, flush=True)
+
+
+def is_enabled() -> bool:
+    return _enabled
+
+
+def _resolve_endpoint() -> str | None:
+    return os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or os.getenv(
+        "_APP_TELEMETRY_OTLP_ENDPOINT"
+    )
+
+
+def init_telemetry(transport: str, version: str) -> bool:
+    """Configure the global meter provider and build instruments.
+
+    Returns True if telemetry was enabled. A no-op (returns False) unless the
+    transport is ``http`` and an OTLP endpoint is configured.
+    """
+    global _enabled
+    with _lock:
+        if _enabled:
+            return True
+
+        if transport != "http":
+            return False
+
+        endpoint = _resolve_endpoint()
+        if not endpoint:
+            _log("disabled: no OTLP endpoint configured")
+            return False
+
+        try:
+            from opentelemetry import metrics
+            from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+                OTLPMetricExporter,
+            )
+            from opentelemetry.sdk.metrics import MeterProvider
+            from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+            from opentelemetry.sdk.resources import Resource
+
+            # Map the cloud-style aliases onto the standard OTel env vars the SDK
+            # reads, without clobbering an explicit standard setting.
+            os.environ.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint)
+            alias_headers = os.getenv("_APP_TELEMETRY_OTLP_HEADERS")
+            if alias_headers and not os.getenv("OTEL_EXPORTER_OTLP_HEADERS"):
+                os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = alias_headers
+
+            # Resource.create() merges OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES
+            # from the environment over these defaults.
+            resource = Resource.create(
+                {
+                    "service.name": "mcp-server-appwrite",
+                    "service.namespace": "appwrite",
+                    "service.version": version,
+                    "service.instance.id": _instance_id(),
+                }
+            )
+            reader = PeriodicExportingMetricReader(
+                OTLPMetricExporter(), export_interval_millis=60_000
+            )
+            provider = MeterProvider(resource=resource, metric_readers=[reader])
+            metrics.set_meter_provider(provider)
+            meter = provider.get_meter("mcp_server_appwrite", version)
+            _build_instruments(meter, transport, version)
+        except Exception as exc:  # pragma: no cover - defensive
+            _log(f"disabled: failed to initialize ({exc})")
+            return False
+
+        _enabled = True
+        _log(f"enabled: exporting metrics to {endpoint}")
+        return True
+
+
+def _instance_id() -> str:
+    return os.getenv("HOSTNAME") or socket.gethostname() or "unknown"
+
+
+def _build_instruments(meter: Any, transport: str, version: str) -> None:
+    _instruments["initializations"] = meter.create_counter(
+        "mcp.initializations",
+        unit="{init}",
+        description="MCP initialize handshakes (connections / logins).",
+    )
+    _instruments["requests"] = meter.create_counter(
+        "mcp.requests",
+        unit="{request}",
+        description="MCP JSON-RPC requests handled.",
+    )
+    _instruments["request_duration"] = meter.create_histogram(
+        "mcp.request.duration",
+        unit="s",
+        description="MCP request handler duration.",
+    )
+    _instruments["tool_calls"] = meter.create_counter(
+        "mcp.tool.calls",
+        unit="{call}",
+        description="Public operator tool invocations.",
+    )
+    _instruments["tool_duration"] = meter.create_histogram(
+        "mcp.tool.duration",
+        unit="s",
+        description="Public operator tool duration.",
+    )
+    _instruments["appwrite_calls"] = meter.create_counter(
+        "mcp.appwrite.calls",
+        unit="{call}",
+        description="Hidden Appwrite catalog tool executions.",
+    )
+    _instruments["appwrite_call_duration"] = meter.create_histogram(
+        "mcp.appwrite.call.duration",
+        unit="s",
+        description="Underlying Appwrite REST call duration.",
+    )
+    _instruments["appwrite_errors"] = meter.create_counter(
+        "mcp.appwrite.errors",
+        unit="{error}",
+        description="Failed Appwrite catalog tool executions.",
+    )
+    _instruments["write_confirmations"] = meter.create_counter(
+        "mcp.write.confirmations",
+        unit="{confirmation}",
+        description="Write/delete confirmation outcomes (confirmed vs blocked).",
+    )
+    _instruments["search_tools_queries"] = meter.create_counter(
+        "mcp.search_tools.queries",
+        unit="{query}",
+        description="appwrite_search_tools catalog searches.",
+    )
+    _instruments["search_tools_results"] = meter.create_histogram(
+        "mcp.search_tools.results",
+        unit="{match}",
+        description="Match count returned by appwrite_search_tools.",
+    )
+    _instruments["search_docs_queries"] = meter.create_counter(
+        "mcp.search_docs.queries",
+        unit="{query}",
+        description="appwrite_search_docs documentation searches.",
+    )
+    _instruments["search_docs_embedding_duration"] = meter.create_histogram(
+        "mcp.search_docs.embedding.duration",
+        unit="s",
+        description="Query embedding duration for docs search.",
+    )
+    _instruments["context_requests"] = meter.create_counter(
+        "mcp.context.requests",
+        unit="{request}",
+        description="appwrite_get_context invocations.",
+    )
+    _instruments["auth_validations"] = meter.create_counter(
+        "mcp.auth.validations",
+        unit="{validation}",
+        description="Bearer-token validation outcomes.",
+    )
+    _instruments["auth_duration"] = meter.create_histogram(
+        "mcp.auth.duration",
+        unit="s",
+        description="Bearer-token verification duration.",
+    )
+    _instruments["results_stored"] = meter.create_counter(
+        "mcp.results.stored",
+        unit="{result}",
+        description="Large tool results spilled to MCP resources.",
+    )
+    _instruments["resources_reads"] = meter.create_counter(
+        "mcp.resources.reads",
+        unit="{read}",
+        description="resources/read calls.",
+    )
+    _instruments["uploads"] = meter.create_counter(
+        "mcp.uploads",
+        unit="{upload}",
+        description="File upload attempts.",
+    )
+    _instruments["upload_bytes"] = meter.create_histogram(
+        "mcp.upload.bytes",
+        unit="By",
+        description="Uploaded file size.",
+    )
+    _instruments["upload_errors"] = meter.create_counter(
+        "mcp.upload.errors",
+        unit="{error}",
+        description="File upload failures.",
+    )
+    _instruments["startup_validation"] = meter.create_counter(
+        "mcp.startup.validation",
+        unit="{probe}",
+        description="Startup service-validation probe outcomes.",
+    )
+
+    # Observable gauges: distinct active users/clients over a rolling window, and a
+    # build-info gauge (always 1, carries version/transport labels).
+    meter.create_observable_gauge(
+        "mcp.users.active",
+        callbacks=[_observe_active_users],
+        unit="{user}",
+        description="Distinct authenticated users seen in the last 5 minutes.",
+    )
+    meter.create_observable_gauge(
+        "mcp.clients.active",
+        callbacks=[_observe_active_clients],
+        unit="{client}",
+        description="Distinct connected agents seen in the last 5 minutes.",
+    )
+
+    def _observe_info(_options: Any):
+        from opentelemetry.metrics import Observation
+
+        return [Observation(1, {"version": version, "transport": transport})]
+
+    meter.create_observable_gauge(
+        "mcp.server.info",
+        callbacks=[_observe_info],
+        unit="{server}",
+        description="Server build info (value is always 1).",
+    )
+
+
+# --- Active-set bookkeeping -------------------------------------------------
+
+
+def _prune(store: dict[str, float], now: float) -> None:
+    expired = [key for key, ts in store.items() if ts < now]
+    for key in expired:
+        del store[key]
+
+
+def _observe_active_users(_options: Any) -> Iterable[Any]:
+    from opentelemetry.metrics import Observation
+
+    now = time.monotonic()
+    with _active_lock:
+        _prune(_active_users, now)
+        count = len(_active_users)
+    return [Observation(count)]
+
+
+def _observe_active_clients(_options: Any) -> Iterable[Any]:
+    from opentelemetry.metrics import Observation
+
+    now = time.monotonic()
+    counts: dict[str, int] = {}
+    with _active_lock:
+        _prune(_active_clients, now)
+        for compound_key in _active_clients:
+            client_name = compound_key.split("\x00", 1)[0]
+            counts[client_name] = counts.get(client_name, 0) + 1
+    return [Observation(n, {"client.name": name}) for name, n in counts.items()]
+
+
+def _touch_user(subject: str | None) -> None:
+    if not subject:
+        return
+    expiry = time.monotonic() + _ACTIVE_WINDOW_SECONDS
+    with _active_lock:
+        _active_users[subject] = expiry
+
+
+def _touch_client(client_name: str | None, subject: str | None) -> None:
+    # Keyed by (client_name, subject) so the per-client gauge counts distinct users
+    # of each agent. subject stays in-process only.
+    if not client_name:
+        return
+    key = f"{client_name}\x00{subject or ''}"
+    expiry = time.monotonic() + _ACTIVE_WINDOW_SECONDS
+    with _active_lock:
+        _active_clients[key] = expiry
+
+
+# --- Record helpers (all exception-safe, no-op when disabled) ---------------
+
+
+def _safe_add(name: str, value: int, attributes: dict[str, Any]) -> None:
+    if not _enabled:
+        return
+    try:
+        _instruments[name].add(value, _clean(attributes))
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _safe_record(name: str, value: float, attributes: dict[str, Any]) -> None:
+    if not _enabled:
+        return
+    try:
+        _instruments[name].record(value, _clean(attributes))
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _clean(attributes: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in attributes.items() if v is not None}
+
+
+def record_request(method: str, outcome: str, duration_s: float) -> None:
+    _safe_add("requests", 1, {"mcp.method": method, "outcome": outcome})
+    _safe_record(
+        "request_duration", duration_s, {"mcp.method": method, "outcome": outcome}
+    )
+
+
+def record_initialize(
+    *,
+    session_id: int,
+    client_name: str | None,
+    client_version: str | None,
+    protocol_version: str | None,
+    oauth_client_id: str | None,
+    subject: str | None,
+) -> None:
+    # Track active users/clients regardless of whether this is a new session.
+    _touch_user(subject)
+    _touch_client(client_name, subject)
+    if not _enabled:
+        return
+    with _active_lock:
+        if session_id in _seen_sessions:
+            return
+        _seen_sessions.add(session_id)
+        # Bound the dedupe set so it can't grow without limit on a long-lived process.
+        if len(_seen_sessions) > 100_000:
+            _seen_sessions.clear()
+            _seen_sessions.add(session_id)
+    _safe_add(
+        "initializations",
+        1,
+        {
+            "client.name": client_name or "unknown",
+            "client.version": client_version,
+            "mcp.protocol.version": protocol_version,
+            "oauth.client_id": oauth_client_id,
+        },
+    )
+
+
+def record_tool_call(tool_name: str, outcome: str, duration_s: float) -> None:
+    _safe_add("tool_calls", 1, {"tool.name": tool_name, "outcome": outcome})
+    _safe_record(
+        "tool_duration", duration_s, {"tool.name": tool_name, "outcome": outcome}
+    )
+
+
+def record_appwrite_call(
+    *,
+    service: str,
+    action: str,
+    classification: str,
+    outcome: str,
+    duration_s: float,
+    error_code: Any = None,
+    error_type: str | None = None,
+) -> None:
+    attrs = {
+        "appwrite.service": service or "unknown",
+        "appwrite.action": action or "unknown",
+        "appwrite.classification": classification or "unknown",
+        "outcome": outcome,
+    }
+    _safe_add("appwrite_calls", 1, attrs)
+    _safe_record(
+        "appwrite_call_duration",
+        duration_s,
+        {
+            "appwrite.service": service or "unknown",
+            "appwrite.action": action or "unknown",
+        },
+    )
+    if outcome == "error":
+        _safe_add(
+            "appwrite_errors",
+            1,
+            {
+                "appwrite.service": service or "unknown",
+                "appwrite.action": action or "unknown",
+                "error.code": str(error_code) if error_code is not None else "unknown",
+                "error.type": error_type or "unknown",
+            },
+        )
+
+
+def record_write_confirmation(classification: str, outcome: str) -> None:
+    _safe_add(
+        "write_confirmations",
+        1,
+        {"appwrite.classification": classification, "outcome": outcome},
+    )
+
+
+def record_search_tools(*, include_mutating: bool, match_count: int) -> None:
+    _safe_add(
+        "search_tools_queries",
+        1,
+        {"include_mutating": include_mutating, "matched": match_count > 0},
+    )
+    _safe_record("search_tools_results", match_count, {})
+
+
+def record_search_docs(
+    *, outcome: str, match_count: int, embedding_duration_s: float | None = None
+) -> None:
+    _safe_add(
+        "search_docs_queries", 1, {"outcome": outcome, "matched": match_count > 0}
+    )
+    if embedding_duration_s is not None:
+        _safe_record(
+            "search_docs_embedding_duration", embedding_duration_s, {"outcome": outcome}
+        )
+
+
+def record_context_request(*, mode: str, include_services: bool) -> None:
+    _safe_add(
+        "context_requests", 1, {"mode": mode, "include_services": include_services}
+    )
+
+
+def record_auth(
+    *,
+    outcome: str,
+    reason: str | None = None,
+    duration_s: float | None = None,
+    count: bool = True,
+) -> None:
+    if count:
+        _safe_add("auth_validations", 1, {"outcome": outcome, "reason": reason})
+    if duration_s is not None:
+        _safe_record("auth_duration", duration_s, {"outcome": outcome})
+
+
+def record_result_stored(tool_name: str) -> None:
+    _safe_add("results_stored", 1, {"tool.name": tool_name})
+
+
+def record_resource_read(resource_type: str) -> None:
+    _safe_add("resources_reads", 1, {"resource.type": resource_type})
+
+
+def record_upload(*, source: str, outcome: str, size_bytes: int | None = None) -> None:
+    _safe_add("uploads", 1, {"source": source, "outcome": outcome})
+    if outcome == "success" and size_bytes is not None:
+        _safe_record("upload_bytes", size_bytes, {"source": source})
+
+
+def record_upload_error(reason: str) -> None:
+    _safe_add("upload_errors", 1, {"reason": reason})
+
+
+def record_startup_validation(service: str, outcome: str) -> None:
+    _safe_add("startup_validation", 1, {"service": service, "outcome": outcome})

--- a/src/mcp_server_appwrite/telemetry.py
+++ b/src/mcp_server_appwrite/telemetry.py
@@ -359,11 +359,14 @@ def record_initialize(
     oauth_client_id: str | None,
     subject: str | None,
 ) -> None:
-    # Track active users/clients regardless of whether this is a new session.
-    _touch_user(subject)
-    _touch_client(client_name, subject)
     if not _enabled:
         return
+    # Refresh active-user/client tracking on every request (not just new sessions)
+    # so the rolling-window gauges reflect recency. Entries are expired by the gauge
+    # callbacks during the SDK's collection cycle — which only runs while enabled, so
+    # these sets must not be touched when telemetry is disabled (they'd never prune).
+    _touch_user(subject)
+    _touch_client(client_name, subject)
     with _active_lock:
         if session_id in _seen_sessions:
             return

--- a/src/mcp_server_appwrite/telemetry.py
+++ b/src/mcp_server_appwrite/telemetry.py
@@ -21,12 +21,11 @@ Design notes:
 Configuration (env):
 
 * ``OTEL_EXPORTER_OTLP_ENDPOINT`` — OTLP/HTTP endpoint; setting it enables export.
-* ``OTEL_EXPORTER_OTLP_HEADERS`` — export headers. If unset, it is assembled from
-  ``CF_ACCESS_CLIENT_ID`` + ``CF_ACCESS_CLIENT_SECRET`` (the shared Cloudflare
-  Access service-token secret) so the deployment passes those two vars directly.
+  In the cluster this points at the in-cluster Alloy collector, which authenticates
+  and forwards upstream and stamps the ``deployment.*`` resource attributes — so the
+  app needs no credentials and no per-deployment resource attributes.
 * ``OTEL_SERVICE_NAME`` / ``OTEL_RESOURCE_ATTRIBUTES`` — picked up by the SDK to set
-  ``service.name`` and ``deployment.environment`` / ``deployment.region`` etc., so
-  the existing Grafana dashboards' label filters apply unchanged.
+  ``service.name`` etc.
 """
 
 from __future__ import annotations
@@ -68,21 +67,6 @@ def _resolve_endpoint() -> str | None:
     return os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 
 
-def _ensure_otlp_headers_env() -> None:
-    """Assemble ``OTEL_EXPORTER_OTLP_HEADERS`` (a single string the SDK reads) from
-    the two Cloudflare Access service-token vars, so the deployment can pass
-    ``CF_ACCESS_CLIENT_ID`` + ``CF_ACCESS_CLIENT_SECRET`` directly and reuse the
-    shared ``telemetry-auth`` secret. A pre-set header value wins."""
-    if os.getenv("OTEL_EXPORTER_OTLP_HEADERS"):
-        return
-    cf_id = os.getenv("CF_ACCESS_CLIENT_ID")
-    cf_secret = os.getenv("CF_ACCESS_CLIENT_SECRET")
-    if cf_id and cf_secret:
-        os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = (
-            f"CF-Access-Client-Id={cf_id},CF-Access-Client-Secret={cf_secret}"
-        )
-
-
 def init_telemetry(transport: str, version: str) -> bool:
     """Configure the global meter provider and build instruments.
 
@@ -112,7 +96,6 @@ def init_telemetry(transport: str, version: str) -> bool:
             from opentelemetry.sdk.resources import Resource
 
             os.environ.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint)
-            _ensure_otlp_headers_env()
 
             # Resource.create() merges OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES
             # from the environment over these defaults.

--- a/src/mcp_server_appwrite/telemetry.py
+++ b/src/mcp_server_appwrite/telemetry.py
@@ -20,9 +20,10 @@ Design notes:
 
 Configuration (env):
 
-* ``OTEL_EXPORTER_OTLP_ENDPOINT`` / ``OTEL_EXPORTER_OTLP_HEADERS`` — standard OTel.
-* ``_APP_TELEMETRY_OTLP_ENDPOINT`` / ``_APP_TELEMETRY_OTLP_HEADERS`` — cloud-style
-  aliases, accepted for parity with the PHP services and existing deploy config.
+* ``OTEL_EXPORTER_OTLP_ENDPOINT`` — OTLP/HTTP endpoint; setting it enables export.
+* ``OTEL_EXPORTER_OTLP_HEADERS`` — export headers. If unset, it is assembled from
+  ``CF_ACCESS_CLIENT_ID`` + ``CF_ACCESS_CLIENT_SECRET`` (the shared Cloudflare
+  Access service-token secret) so the deployment passes those two vars directly.
 * ``OTEL_SERVICE_NAME`` / ``OTEL_RESOURCE_ATTRIBUTES`` — picked up by the SDK to set
   ``service.name`` and ``deployment.environment`` / ``deployment.region`` etc., so
   the existing Grafana dashboards' label filters apply unchanged.
@@ -64,9 +65,22 @@ def is_enabled() -> bool:
 
 
 def _resolve_endpoint() -> str | None:
-    return os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or os.getenv(
-        "_APP_TELEMETRY_OTLP_ENDPOINT"
-    )
+    return os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+
+def _ensure_otlp_headers_env() -> None:
+    """Assemble ``OTEL_EXPORTER_OTLP_HEADERS`` (a single string the SDK reads) from
+    the two Cloudflare Access service-token vars, so the deployment can pass
+    ``CF_ACCESS_CLIENT_ID`` + ``CF_ACCESS_CLIENT_SECRET`` directly and reuse the
+    shared ``telemetry-auth`` secret. A pre-set header value wins."""
+    if os.getenv("OTEL_EXPORTER_OTLP_HEADERS"):
+        return
+    cf_id = os.getenv("CF_ACCESS_CLIENT_ID")
+    cf_secret = os.getenv("CF_ACCESS_CLIENT_SECRET")
+    if cf_id and cf_secret:
+        os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = (
+            f"CF-Access-Client-Id={cf_id},CF-Access-Client-Secret={cf_secret}"
+        )
 
 
 def init_telemetry(transport: str, version: str) -> bool:
@@ -97,12 +111,8 @@ def init_telemetry(transport: str, version: str) -> bool:
             from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
             from opentelemetry.sdk.resources import Resource
 
-            # Map the cloud-style aliases onto the standard OTel env vars the SDK
-            # reads, without clobbering an explicit standard setting.
             os.environ.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint)
-            alias_headers = os.getenv("_APP_TELEMETRY_OTLP_HEADERS")
-            if alias_headers and not os.getenv("OTEL_EXPORTER_OTLP_HEADERS"):
-                os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = alias_headers
+            _ensure_otlp_headers_env()
 
             # Resource.create() merges OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES
             # from the environment over these defaults.

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 import mcp.types as types
@@ -242,46 +241,6 @@ class NoOpTests(unittest.TestCase):
 
     def test_init_is_noop_for_stdio(self):
         self.assertFalse(telemetry.init_telemetry("stdio", "test"))
-
-
-class OtlpHeadersResolutionTests(unittest.TestCase):
-    """_ensure_otlp_headers_env composes OTEL_EXPORTER_OTLP_HEADERS from the
-    accepted inputs without clobbering an explicit value."""
-
-    def setUp(self):
-        self._keys = (
-            "OTEL_EXPORTER_OTLP_HEADERS",
-            "CF_ACCESS_CLIENT_ID",
-            "CF_ACCESS_CLIENT_SECRET",
-        )
-        self._saved = {k: os.environ.pop(k, None) for k in self._keys}
-
-    def tearDown(self):
-        for k in self._keys:
-            os.environ.pop(k, None)
-            if self._saved[k] is not None:
-                os.environ[k] = self._saved[k]
-
-    def test_assembles_header_from_cf_access_vars(self):
-        os.environ["CF_ACCESS_CLIENT_ID"] = "abc.access"
-        os.environ["CF_ACCESS_CLIENT_SECRET"] = "shh"
-        telemetry._ensure_otlp_headers_env()
-        self.assertEqual(
-            os.environ["OTEL_EXPORTER_OTLP_HEADERS"],
-            "CF-Access-Client-Id=abc.access,CF-Access-Client-Secret=shh",
-        )
-
-    def test_does_not_clobber_explicit_headers(self):
-        os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = "X-Custom=1"
-        os.environ["CF_ACCESS_CLIENT_ID"] = "abc"
-        os.environ["CF_ACCESS_CLIENT_SECRET"] = "shh"
-        telemetry._ensure_otlp_headers_env()
-        self.assertEqual(os.environ["OTEL_EXPORTER_OTLP_HEADERS"], "X-Custom=1")
-
-    def test_noop_when_only_one_cf_access_var(self):
-        os.environ["CF_ACCESS_CLIENT_ID"] = "abc"
-        telemetry._ensure_otlp_headers_env()
-        self.assertNotIn("OTEL_EXPORTER_OTLP_HEADERS", os.environ)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import mcp.types as types
@@ -241,6 +242,46 @@ class NoOpTests(unittest.TestCase):
 
     def test_init_is_noop_for_stdio(self):
         self.assertFalse(telemetry.init_telemetry("stdio", "test"))
+
+
+class OtlpHeadersResolutionTests(unittest.TestCase):
+    """_ensure_otlp_headers_env composes OTEL_EXPORTER_OTLP_HEADERS from the
+    accepted inputs without clobbering an explicit value."""
+
+    def setUp(self):
+        self._keys = (
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "CF_ACCESS_CLIENT_ID",
+            "CF_ACCESS_CLIENT_SECRET",
+        )
+        self._saved = {k: os.environ.pop(k, None) for k in self._keys}
+
+    def tearDown(self):
+        for k in self._keys:
+            os.environ.pop(k, None)
+            if self._saved[k] is not None:
+                os.environ[k] = self._saved[k]
+
+    def test_assembles_header_from_cf_access_vars(self):
+        os.environ["CF_ACCESS_CLIENT_ID"] = "abc.access"
+        os.environ["CF_ACCESS_CLIENT_SECRET"] = "shh"
+        telemetry._ensure_otlp_headers_env()
+        self.assertEqual(
+            os.environ["OTEL_EXPORTER_OTLP_HEADERS"],
+            "CF-Access-Client-Id=abc.access,CF-Access-Client-Secret=shh",
+        )
+
+    def test_does_not_clobber_explicit_headers(self):
+        os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = "X-Custom=1"
+        os.environ["CF_ACCESS_CLIENT_ID"] = "abc"
+        os.environ["CF_ACCESS_CLIENT_SECRET"] = "shh"
+        telemetry._ensure_otlp_headers_env()
+        self.assertEqual(os.environ["OTEL_EXPORTER_OTLP_HEADERS"], "X-Custom=1")
+
+    def test_noop_when_only_one_cf_access_var(self):
+        os.environ["CF_ACCESS_CLIENT_ID"] = "abc"
+        telemetry._ensure_otlp_headers_env()
+        self.assertNotIn("OTEL_EXPORTER_OTLP_HEADERS", os.environ)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,247 @@
+import unittest
+
+import mcp.types as types
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from mcp_server_appwrite import telemetry
+from mcp_server_appwrite.operator import Operator
+from mcp_server_appwrite.tool_manager import ToolManager
+
+
+def make_tool(
+    name: str, description: str, required: list[str] | None = None
+) -> types.Tool:
+    return types.Tool(
+        name=name,
+        description=description,
+        inputSchema={
+            "type": "object",
+            "properties": {"parameter": {"type": "string"}},
+            "required": required or [],
+        },
+    )
+
+
+class TelemetryHarness(unittest.TestCase):
+    """Base class that wires telemetry to an in-memory reader for assertions."""
+
+    def setUp(self) -> None:
+        self.reader = InMemoryMetricReader()
+        provider = MeterProvider(metric_readers=[self.reader])
+        meter = provider.get_meter("test")
+        telemetry._instruments.clear()
+        telemetry._build_instruments(meter, "http", "test")
+        telemetry._enabled = True
+
+    def tearDown(self) -> None:
+        telemetry._enabled = False
+        telemetry._instruments.clear()
+        with telemetry._active_lock:
+            telemetry._active_users.clear()
+            telemetry._active_clients.clear()
+            telemetry._seen_sessions.clear()
+
+    def points(self, metric_name: str) -> list:
+        data = self.reader.get_metrics_data()
+        if data is None:
+            return []
+        for resource_metrics in data.resource_metrics:
+            for scope_metrics in resource_metrics.scope_metrics:
+                for metric in scope_metrics.metrics:
+                    if metric.name == metric_name:
+                        return list(metric.data.data_points)
+        return []
+
+    def assertAttr(self, point, key, value):
+        self.assertEqual(point.attributes.get(key), value)
+
+
+class RecordHelperTests(TelemetryHarness):
+    def test_appwrite_call_success_labels(self):
+        telemetry.record_appwrite_call(
+            service="storage",
+            action="create",
+            classification="write",
+            outcome="success",
+            duration_s=0.05,
+        )
+        points = self.points("mcp.appwrite.calls")
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0].value, 1)
+        self.assertAttr(points[0], "appwrite.service", "storage")
+        self.assertAttr(points[0], "appwrite.action", "create")
+        self.assertAttr(points[0], "appwrite.classification", "write")
+        self.assertAttr(points[0], "outcome", "success")
+        # No error counter on success.
+        self.assertEqual(self.points("mcp.appwrite.errors"), [])
+
+    def test_appwrite_call_error_emits_error_counter(self):
+        telemetry.record_appwrite_call(
+            service="users",
+            action="get",
+            classification="read",
+            outcome="error",
+            duration_s=0.01,
+            error_code=404,
+            error_type="user_not_found",
+        )
+        errors = self.points("mcp.appwrite.errors")
+        self.assertEqual(len(errors), 1)
+        self.assertAttr(errors[0], "appwrite.service", "users")
+        self.assertAttr(errors[0], "error.code", "404")
+        self.assertAttr(errors[0], "error.type", "user_not_found")
+
+    def test_auth_rejected_then_duration_without_double_count(self):
+        # _verify_sync-style: counter with reason, no duration.
+        telemetry.record_auth(outcome="rejected", reason="signature")
+        # verify_token-style: duration only, no counter.
+        telemetry.record_auth(outcome="rejected", duration_s=0.02, count=False)
+        validations = self.points("mcp.auth.validations")
+        self.assertEqual(len(validations), 1)
+        self.assertEqual(validations[0].value, 1)
+        self.assertAttr(validations[0], "reason", "signature")
+
+    def test_active_users_gauge_counts_distinct_subjects(self):
+        telemetry.record_initialize(
+            session_id=1,
+            client_name="claude",
+            client_version="1.0",
+            protocol_version="2025-06-18",
+            oauth_client_id="app-1",
+            subject="user-a",
+        )
+        telemetry.record_initialize(
+            session_id=2,
+            client_name="claude",
+            client_version="1.0",
+            protocol_version="2025-06-18",
+            oauth_client_id="app-1",
+            subject="user-b",
+        )
+        users = self.points("mcp.users.active")
+        self.assertEqual(users[0].value, 2)
+        inits = self.points("mcp.initializations")
+        self.assertEqual(sum(p.value for p in inits), 2)
+        self.assertAttr(inits[0], "client.name", "claude")
+
+    def test_initialize_deduped_per_session(self):
+        for _ in range(3):
+            telemetry.record_initialize(
+                session_id=42,
+                client_name="cursor",
+                client_version="2.0",
+                protocol_version="2025-06-18",
+                oauth_client_id="app-2",
+                subject="user-c",
+            )
+        inits = self.points("mcp.initializations")
+        self.assertEqual(sum(p.value for p in inits), 1)
+
+
+class OperatorTelemetryTests(TelemetryHarness):
+    def make_runtime(self, executor):
+        manager = ToolManager()
+        manager.tools_registry = {
+            "tables_db_list": {
+                "definition": make_tool("tables_db_list", "List all databases."),
+                "function": object(),
+                "parameter_types": {},
+            },
+            "tables_db_create": {
+                "definition": make_tool(
+                    "tables_db_create", "Create a database.", ["database_id"]
+                ),
+                "function": object(),
+                "parameter_types": {},
+            },
+        }
+        return Operator(manager, executor)
+
+    def test_write_confirmation_blocked(self):
+        runtime = self.make_runtime(lambda name, arguments, *_: [])
+        with self.assertRaises(RuntimeError):
+            runtime.execute_public_tool(
+                "appwrite_call_tool",
+                {"tool_name": "tables_db_create", "arguments": {"database_id": "db"}},
+            )
+        confirmations = self.points("mcp.write.confirmations")
+        self.assertEqual(len(confirmations), 1)
+        self.assertAttr(confirmations[0], "outcome", "blocked")
+        self.assertAttr(confirmations[0], "appwrite.classification", "write")
+
+    def test_write_confirmation_confirmed(self):
+        runtime = self.make_runtime(
+            lambda name, arguments, *_: [types.TextContent(type="text", text="ok")]
+        )
+        runtime.execute_public_tool(
+            "appwrite_call_tool",
+            {
+                "tool_name": "tables_db_create",
+                "confirm_write": True,
+                "database_id": "db",
+            },
+        )
+        confirmed = [
+            p
+            for p in self.points("mcp.write.confirmations")
+            if p.attributes.get("outcome") == "confirmed"
+        ]
+        self.assertEqual(len(confirmed), 1)
+
+    def test_tool_call_counter(self):
+        runtime = self.make_runtime(
+            lambda name, arguments, *_: [types.TextContent(type="text", text="ok")]
+        )
+        runtime.execute_public_tool(
+            "appwrite_call_tool", {"tool_name": "tables_db_list"}
+        )
+        calls = self.points("mcp.tool.calls")
+        self.assertTrue(
+            any(
+                p.attributes.get("tool.name") == "appwrite_call_tool"
+                and p.attributes.get("outcome") == "success"
+                for p in calls
+            )
+        )
+
+
+class NoOpTests(unittest.TestCase):
+    def test_no_emission_when_disabled(self):
+        # Disabled with instruments registered on a live reader: record_* must be a
+        # no-op so the reader collects no MCP counters/histograms.
+        reader = InMemoryMetricReader()
+        provider = MeterProvider(metric_readers=[reader])
+        telemetry._instruments.clear()
+        telemetry._build_instruments(provider.get_meter("test"), "http", "test")
+        telemetry._enabled = False
+        try:
+            telemetry.record_request("tools/call", "success", 0.01)
+            telemetry.record_appwrite_call(
+                service="storage",
+                action="create",
+                classification="write",
+                outcome="success",
+                duration_s=0.01,
+            )
+            telemetry.record_auth(outcome="rejected", reason="malformed")
+
+            recorded = {
+                metric.name
+                for rm in reader.get_metrics_data().resource_metrics
+                for sm in rm.scope_metrics
+                for metric in sm.metrics
+                if metric.data.data_points
+            }
+            self.assertNotIn("mcp.requests", recorded)
+            self.assertNotIn("mcp.appwrite.calls", recorded)
+            self.assertNotIn("mcp.auth.validations", recorded)
+        finally:
+            telemetry._instruments.clear()
+
+    def test_init_is_noop_for_stdio(self):
+        self.assertFalse(telemetry.init_telemetry("stdio", "test"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -242,6 +242,23 @@ class NoOpTests(unittest.TestCase):
     def test_init_is_noop_for_stdio(self):
         self.assertFalse(telemetry.init_telemetry("stdio", "test"))
 
+    def test_record_initialize_does_not_grow_sets_when_disabled(self):
+        # When disabled, the active-user/client sets must not accumulate — they are
+        # only pruned by the gauge callbacks, which never run while disabled.
+        telemetry._enabled = False
+        telemetry._active_users.clear()
+        telemetry._active_clients.clear()
+        telemetry.record_initialize(
+            session_id=7,
+            client_name="claude",
+            client_version="1.0",
+            protocol_version="2025-06-18",
+            oauth_client_id="app",
+            subject="user-x",
+        )
+        self.assertEqual(len(telemetry._active_users), 0)
+        self.assertEqual(len(telemetry._active_clients), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -392,6 +392,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -636,6 +648,9 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "numpy" },
     { name = "openai" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "starlette", version = "0.46.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -668,6 +683,9 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.0" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "openai", specifier = ">=1.40" },
+    { name = "opentelemetry-api", specifier = ">=1.27" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27" },
+    { name = "opentelemetry-sdk", specifier = ">=1.27" },
     { name = "passlib", marker = "extra == 'integration'", specifier = ">=1.7.4" },
     { name = "pycryptodome", marker = "extra == 'integration'", specifier = ">=3.20.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9.0" },
@@ -773,6 +791,87 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -806,6 +905,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

The MCP server emitted no telemetry. The other Appwrite services use `utopia-php/telemetry` to export OpenTelemetry metrics over OTLP/HTTP to the shared stack (OTel Collector → Prometheus/Mimir → Grafana at `telemetry.appwrite.systems`). This wires the **hosted HTTP** MCP server into that same stack so we can see:

1. **Request rate per endpoint** — MCP methods and per Appwrite service/action.
2. **Which agents connect** — MCP `clientInfo` (Claude, Cursor, …) + OAuth client_id.
3. **Logins / active users** — initialize handshakes and distinct authenticated users.
4. **Errors, latency, write confirmations, search/docs usage, uploads, auth rejections.**

## Approach

- New **`telemetry.py`** owns the `MeterProvider`, all instruments, in-process active user/client TTL sets, and exception-safe `record_*` helpers. **No-op unless transport is `http` and an OTLP endpoint is configured** — self-hosted `stdio` never phones home; an unconfigured hosted server stays silent (mirrors the PHP `None`/`NoTelemetry` adapter).
- Instrumented at the operator/handler/auth boundaries (`server.py`, `operator.py`, `auth.py`, `http_app.py`, `docs_search.py`).
- **Cardinality discipline:** user ids (`sub`) are never labels — distinct counts are derived in-process and exposed only via the aggregate gauges `mcp.users.active` / `mcp.clients.active`.

## Metrics

Prefixed `mcp.` — `mcp.requests`, `mcp.request.duration`, `mcp.tool.calls`, `mcp.appwrite.calls` / `.call.duration` / `.errors`, `mcp.write.confirmations`, `mcp.initializations`, `mcp.users.active`, `mcp.clients.active`, `mcp.auth.validations` / `.duration`, `mcp.search_tools.*`, `mcp.search_docs.*`, `mcp.context.requests`, `mcp.results.stored`, `mcp.resources.reads`, `mcp.uploads` / `.upload.bytes` / `.upload.errors`, `mcp.server.info`, `mcp.startup.validation`.

## Config

Standard `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS` / `OTEL_RESOURCE_ATTRIBUTES`, plus the cloud-style `_APP_TELEMETRY_OTLP_ENDPOINT` / `_APP_TELEMETRY_OTLP_HEADERS` aliases. Documented in `AGENTS.md` and `compose.yaml`. Runtime values are set in the declarative deploy repo (`assets-applications` `<env>/mcp/default.yaml`), not in CI.

## Testing

- New `tests/unit/test_telemetry.py` (in-memory metric reader; no collector needed): label correctness, write-block, auth reasons, session dedupe, and the no-op path.
- All **86 unit tests pass**; ruff + black clean; Docker image builds.
- Verified end-to-end against a real `otel/opentelemetry-collector` — metrics land with correct names/attributes and the `deployment.environment.name` resource attribute flows through.

## Dashboards

Companion Grafana dashboards (`MCP/overview.json`, `MCP/adoption.json`) are in a separate PR against the `dashboards` repo.