### PR TITLE
Bump version to 0.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-appwrite"
-version = "0.8.2"
+version = "0.8.3"
 description = "MCP (Model Context Protocol) server for Appwrite"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcp_server_appwrite/constants.py
+++ b/src/mcp_server_appwrite/constants.py
@@ -14,7 +14,7 @@ from appwrite.models.user import User
 
 # --- server ---------------------------------------------------------------
 
-SERVER_VERSION = "0.8.2"
+SERVER_VERSION = "0.8.3"
 
 DEFAULT_ENDPOINT = "https://cloud.appwrite.io/v1"
 DEFAULT_TRANSPORT = "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ cli = [
 
 [[package]]
 name = "mcp-server-appwrite"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "appwrite" },


### PR DESCRIPTION
The 0.8.3 GitHub release was published without a version bump in the repo, so the Publish workflow ([run 28638962896](https://github.com/appwrite/mcp/actions/runs/28638962896)) built `mcp_server_appwrite-0.8.2` artifacts and PyPI rejected the upload with `400 Bad Request` — 0.8.2 already exists there, and PyPI refuses duplicate filenames.

Bumps `pyproject.toml`, `SERVER_VERSION` in `constants.py` (the `appwrite/mcp:0.8.3` Docker image currently self-reports 0.8.2 on `/healthz`), and `uv.lock`.

**After merging, re-running the failed workflow is not enough** — the publish workflow checks out the release tag, which points at the old commit. The `0.8.3` tag and release need to be moved to (or recreated on) the merge commit, which re-triggers publish and should let the PyPI upload succeed.