### PR TITLE
Route project-scoped calls to the project's home region

### DIFF
--- a/src/mcp_server_appwrite/auth.py
+++ b/src/mcp_server_appwrite/auth.py
@@ -27,9 +27,9 @@ from mcp.server.auth.provider import AccessToken, TokenVerifier
 
 from . import telemetry
 from .constants import (
+    CACHE_TTL_SECONDS,
     DEFAULT_ENDPOINT,
     DEFAULT_PROJECT_ID,
-    DISCOVERY_TTL_SECONDS,
     PREFERRED_SCOPES,
 )
 
@@ -89,7 +89,7 @@ def _cached_discovery(project_id: str, *, allow_stale: bool = False) -> dict | N
     if entry is None:
         return None
     fetched_at, document = entry
-    if allow_stale or time.monotonic() - fetched_at < DISCOVERY_TTL_SECONDS:
+    if allow_stale or time.monotonic() - fetched_at < CACHE_TTL_SECONDS:
         return document
     return None
 

--- a/src/mcp_server_appwrite/constants.py
+++ b/src/mcp_server_appwrite/constants.py
@@ -17,6 +17,8 @@ from appwrite.models.user import User
 SERVER_VERSION = "0.8.3"
 
 DEFAULT_ENDPOINT = "https://cloud.appwrite.io/v1"
+# Region reported by single-region deployments; carries no region subdomain.
+DEFAULT_REGION = "default"
 DEFAULT_TRANSPORT = "stdio"
 TRANSPORTS = {"stdio", "http"}
 VALIDATION_SERVICE_ORDER = (
@@ -57,7 +59,8 @@ PREFERRED_SCOPES = [
     "all",
 ]
 
-DISCOVERY_TTL_SECONDS = 300.0
+# Shared TTL for cached upstream lookups (OAuth discovery, project regions).
+CACHE_TTL_SECONDS = 300.0
 
 # --- http_app -------------------------------------------------------------
 

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -228,7 +228,9 @@ def build_client_for_request(
 # must be addressed through the region subdomain (e.g.
 # ``https://sgp.cloud.appwrite.io/v1``); other gateways reject project-scoped
 # calls with 401 general_access_forbidden. Regions are looked up once per
-# project via the console API and cached briefly.
+# project via the console API and cached briefly; the 'default' sentinel is
+# cached like any region, so a project that migrates regions may be routed to
+# its old home for up to CACHE_TTL_SECONDS.
 _project_region_cache: dict[str, tuple[str, float]] = {}
 
 
@@ -242,6 +244,10 @@ def resolve_region_endpoint(base_endpoint: str, region: str | None) -> str:
     split = urlsplit(base_endpoint)
     hostname = split.hostname or ""
     if not hostname or hostname.startswith(f"{region}."):
+        return base_endpoint
+    if "@" in split.netloc:
+        # Prefixing the netloc would land the region on the userinfo, not the
+        # host; credential-bearing endpoints are never regional, so pass through.
         return base_endpoint
     return urlunsplit(split._replace(netloc=f"{region}.{split.netloc}"))
 

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -261,7 +261,12 @@ def _lookup_project_region(
         project = client.call(
             "get",
             f"/projects/{target_project}",
-            headers={"accept": "application/json"},
+            # The SDK does not turn set_project into a header on raw call();
+            # send the console project header explicitly (as context.py does).
+            headers={
+                "accept": "application/json",
+                "x-appwrite-project": console_project_id,
+            },
             params={},
         )
     except Exception:

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -22,7 +22,7 @@ from enum import Enum
 from pathlib import Path
 from types import UnionType
 from typing import Any, Union, get_args, get_origin
-from urllib.parse import unquote, urlsplit
+from urllib.parse import unquote, urlsplit, urlunsplit
 
 import httpx
 import mcp.server.stdio
@@ -41,8 +41,10 @@ from pydantic import AnyUrl
 
 from . import telemetry
 from .constants import (
+    CACHE_TTL_SECONDS,
     CATALOG_URI,
     DEFAULT_ENDPOINT,
+    DEFAULT_REGION,
     DEFAULT_TRANSPORT,
     EXCLUDED_SERVICES,
     FETCH_MAX_REDIRECTS,
@@ -221,6 +223,59 @@ def build_client_for_request(
     return client
 
 
+# Appwrite Cloud is multi-region: project metadata is global (any gateway can
+# list projects), but a project's data plane lives only in its home region and
+# must be addressed through the region subdomain (e.g.
+# ``https://sgp.cloud.appwrite.io/v1``); other gateways reject project-scoped
+# calls with 401 general_access_forbidden. Regions are looked up once per
+# project via the console API and cached briefly.
+_project_region_cache: dict[str, tuple[str, float]] = {}
+
+
+def resolve_region_endpoint(base_endpoint: str, region: str | None) -> str:
+    """Return the endpoint for a project homed in ``region`` by prefixing the
+    region subdomain onto the configured endpoint. Single-region deployments
+    (which report the ``default`` region), malformed regions, and endpoints
+    already prefixed with the region pass through unchanged."""
+    if not region or region == DEFAULT_REGION or not region.isalnum():
+        return base_endpoint
+    split = urlsplit(base_endpoint)
+    hostname = split.hostname or ""
+    if not hostname or hostname.startswith(f"{region}."):
+        return base_endpoint
+    return urlunsplit(split._replace(netloc=f"{region}.{split.netloc}"))
+
+
+def _lookup_project_region(
+    console_project_id: str, bearer_token: str, target_project: str
+) -> str | None:
+    """Fetch ``target_project``'s home region from the console API. Project
+    metadata is global, so this succeeds from any gateway. Successful lookups
+    are cached; on failure the caller falls back to the configured endpoint,
+    preserving the previous behavior."""
+    cached = _project_region_cache.get(target_project)
+    if cached and cached[1] > time.monotonic():
+        return cached[0]
+    client = build_client_for_request(console_project_id, bearer_token)
+    try:
+        project = client.call(
+            "get",
+            f"/projects/{target_project}",
+            headers={"accept": "application/json"},
+            params={},
+        )
+    except Exception:
+        return None
+    region = project.get("region") if isinstance(project, dict) else None
+    if not isinstance(region, str) or not region:
+        return None
+    _project_region_cache[target_project] = (
+        region,
+        time.monotonic() + CACHE_TTL_SECONDS,
+    )
+    return region
+
+
 def resolve_client(
     target_project: str | None = None, organization_id: str | None = None
 ) -> Client:
@@ -228,7 +283,8 @@ def resolve_client(
     token. The token is read from the request context populated by the auth
     middleware and carries the project it was issued for (the console). Pass
     ``target_project``/``organization_id`` to scope the call to one of the user's
-    own projects/organizations."""
+    own projects/organizations. Project-scoped calls are routed to the target
+    project's home-region endpoint (see ``resolve_region_endpoint``)."""
     access_token = get_access_token()
     if access_token is None:
         raise RuntimeError("No authenticated Appwrite access token in request context.")
@@ -237,9 +293,16 @@ def resolve_client(
     project_id = claims.get("project_id")
     if not project_id:
         raise RuntimeError("Authenticated token is missing a project identifier.")
+
+    base_endpoint = os.getenv("APPWRITE_ENDPOINT", DEFAULT_ENDPOINT)
+    endpoint = base_endpoint
+    if target_project:
+        region = _lookup_project_region(project_id, access_token.token, target_project)
+        endpoint = resolve_region_endpoint(base_endpoint, region)
     return build_client_for_request(
         project_id,
         access_token.token,
+        endpoint=endpoint,
         target_project=target_project,
         organization_id=organization_id,
     )

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -127,7 +127,7 @@ class AuthHelperTests(unittest.TestCase):
             # Age the entry past the TTL.
             fetched_at, doc = auth._discovery_cache[pid]
             auth._discovery_cache[pid] = (
-                fetched_at - auth.DISCOVERY_TTL_SECONDS - 1,
+                fetched_at - auth.CACHE_TTL_SECONDS - 1,
                 doc,
             )
             self.assertIsNone(auth._cached_discovery(pid))
@@ -142,7 +142,7 @@ class AuthHelperTests(unittest.TestCase):
         auth._store_discovery(pid, stale_doc)
         fetched_at, doc = auth._discovery_cache[pid]
         auth._discovery_cache[pid] = (
-            fetched_at - auth.DISCOVERY_TTL_SECONDS - 1,
+            fetched_at - auth.CACHE_TTL_SECONDS - 1,
             doc,
         )
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -666,6 +666,8 @@ class RegionRoutingTests(unittest.TestCase):
             patch.object(server_module, "_lookup_project_region", return_value="sgp"),
         ):
             client = server_module.resolve_client(target_project="proj")
+        # _endpoint is SDK-internal, but it is the only place the resolved
+        # endpoint is observable without a network call (context.py reads it too).
         self.assertEqual(client._endpoint, "https://sgp.cloud.appwrite.io/v1")
 
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import mcp.types as types
 from appwrite.enums.browser import Browser
@@ -23,6 +23,7 @@ from mcp_server_appwrite.server import (
     build_operator,
     parse_args,
     register_services,
+    resolve_region_endpoint,
     validate_services,
 )
 from mcp_server_appwrite.tool_manager import ToolManager
@@ -615,6 +616,57 @@ class UploadInputFileTests(unittest.TestCase):
         self.assertIn("url", http.lower())
         self.assertIn("upload", http.lower())
         self.assertNotIn("upload", stdio.lower())
+
+
+class RegionRoutingTests(unittest.TestCase):
+    BASE = "https://cloud.appwrite.io/v1"
+
+    def setUp(self):
+        server_module._project_region_cache.clear()
+
+    def test_resolve_region_endpoint(self):
+        self.assertEqual(
+            resolve_region_endpoint(self.BASE, "sgp"),
+            "https://sgp.cloud.appwrite.io/v1",
+        )
+        # No region, single-region deployments, malformed regions, and
+        # already-prefixed endpoints pass through unchanged.
+        for region in (None, "default", "sgp.evil.example", "sgp/../x", ""):
+            self.assertEqual(resolve_region_endpoint(self.BASE, region), self.BASE)
+        prefixed = "https://sgp.cloud.appwrite.io/v1"
+        self.assertEqual(resolve_region_endpoint(prefixed, "sgp"), prefixed)
+
+    def test_lookup_project_region_caches_successful_lookups(self):
+        client = Mock()
+        client.call.return_value = {"region": "sgp"}
+        with patch.object(
+            server_module, "build_client_for_request", return_value=client
+        ):
+            for _ in range(2):
+                region = server_module._lookup_project_region("console", "tok", "proj")
+                self.assertEqual(region, "sgp")
+        client.call.assert_called_once()
+
+    def test_lookup_project_region_failure_falls_back_uncached(self):
+        client = Mock()
+        client.call.side_effect = RuntimeError("console unavailable")
+        with patch.object(
+            server_module, "build_client_for_request", return_value=client
+        ):
+            self.assertIsNone(
+                server_module._lookup_project_region("console", "tok", "proj")
+            )
+        self.assertEqual(server_module._project_region_cache, {})
+
+    def test_resolve_client_routes_target_project_to_home_region(self):
+        token = Mock(token="tok", claims={"project_id": "console"})
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(server_module, "get_access_token", return_value=token),
+            patch.object(server_module, "_lookup_project_region", return_value="sgp"),
+        ):
+            client = server_module.resolve_client(target_project="proj")
+        self.assertEqual(client._endpoint, "https://sgp.cloud.appwrite.io/v1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Appwrite Cloud is multi-region: project metadata is global (any gateway can list projects), but a project's data plane lives only in its home region. `resolve_client` built every per-request OAuth client on the configured `APPWRITE_ENDPOINT`, so both `appwrite_call_tool` and `appwrite_get_context` failed for projects homed in another region with:

```
401 general_access_forbidden: Project is not accessible in this region.
Please make sure you are using the correct endpoint
```

The `endpoint` parameter of `build_client_for_request` existed but no caller ever passed it.

## Fix

- `resolve_region_endpoint(base_endpoint, region)` prefixes the project's region subdomain onto the configured endpoint (`https://cloud.appwrite.io/v1` + `sgp` → `https://sgp.cloud.appwrite.io/v1`). No host is hardcoded — the base comes from `APPWRITE_ENDPOINT`. Single-region deployments (which report the `default` region sentinel, now `DEFAULT_REGION` in constants), malformed regions, and already-prefixed endpoints pass through unchanged.
- `_lookup_project_region` fetches the target project's region from the console API (metadata is global, so it works from any gateway) and caches it. Failures fall back to the configured endpoint, preserving prior behavior.
- `resolve_client` threads the regional endpoint into the existing `endpoint` parameter whenever a `target_project` is set. This fixes both `appwrite_call_tool` and the per-project service summaries in `appwrite_get_context`, which share this path.
- The existing `DISCOVERY_TTL_SECONDS` is generalized to `CACHE_TTL_SECONDS`, shared by the OAuth discovery cache and the region cache.

## Testing

- New `RegionRoutingTests` cover the endpoint rewrite (including passthrough cases), lookup caching, uncached failure fallback, and `resolve_client` threading the regional endpoint.
- `ruff`, `black`, `pyright`, and the unit suite (98 tests) all pass.

## Note for reviewers

This assumes regional gateways honor console-issued bearer tokens with `X-Appwrite-Mode: admin` (as the console web app does cross-region). Worth pinning down with an integration test against a real cross-region project before relying on it broadly.