### PR TITLE
Publish Appwrite MCP registry metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install build==1.5.0 twine==6.2.0
 
-      - name: Check release tag matches package version
+      - name: Check release metadata
         run: |
           VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
           TAG="${{ github.event.release.tag_name }}"
           if [ "$TAG" != "v$VERSION" ]; then
             echo "Release tag $TAG does not match pyproject version v$VERSION" >&2
+            exit 1
+          fi
+          SERVER_VERSION="$(python -c 'import json; print(json.load(open("server.json"))["version"])')"
+          if [ "$SERVER_VERSION" != "$VERSION" ]; then
+            echo "server.json version $SERVER_VERSION does not match pyproject version $VERSION" >&2
+            exit 1
+          fi
+          PACKAGE_VERSION="$(python -c 'import json; data=json.load(open("server.json")); print(next(package["version"] for package in data["packages"] if package["identifier"] == "mcp-server-appwrite"))')"
+          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+            echo "server.json package version $PACKAGE_VERSION does not match pyproject version $VERSION" >&2
             exit 1
           fi
 
@@ -54,8 +64,13 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.7.9
+          MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fsSLO "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher_linux_amd64.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher_linux_amd64.tar.gz mcp-publisher
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,10 @@ on:
 
 jobs:
   publish:
-    name: Release build and publish
+    name: Release build and publish to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -22,6 +24,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install build==1.5.0 twine==6.2.0
 
+      - name: Check release tag matches package version
+        run: |
+          VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          TAG="${{ github.event.release.tag_name }}"
+          if [ "$TAG" != "v$VERSION" ]; then
+            echo "Release tag $TAG does not match pyproject version v$VERSION" >&2
+            exit 1
+          fi
+
       - name: Build package
         run: python -m build
 
@@ -30,3 +41,24 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,17 @@ OPENAI_API_KEY=sk-... uv run python scripts/build_docs_index.py
 These are not gated on PRs the way `ci.yml` is, but be mindful when touching the
 `Dockerfile`, `pyproject.toml` version, or deployment config.
 
+### Release metadata
+
+When bumping the package version in `pyproject.toml`, keep `server.json` in sync:
+
+- `server.json.name` must stay `io.github.appwrite/mcp`.
+- `server.json.version` must match `[project].version` in `pyproject.toml`.
+- The `packages[]` entry for `mcp-server-appwrite` must use the same version.
+
+The publish workflow sends `server.json` to the MCP Registry after publishing the
+PyPI package, so stale registry metadata will be published if these drift.
+
 ## Conventions
 
 - Keep the exposed tool surface small — new Appwrite capabilities should flow

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.appwrite/mcp",
   "description": "MCP (Model Context Protocol) server for Appwrite",
-  "version": "0.8.0",
+  "version": "0.8.4",
   "repository": {
     "url": "https://github.com/appwrite/mcp",
     "source": "github"
@@ -15,7 +15,7 @@
   ],
   "packages": [
     {
-      "version": "0.8.0",
+      "version": "0.8.4",
       "registryType": "pypi",
       "identifier": "mcp-server-appwrite",
       "transport": {


### PR DESCRIPTION
## Summary

- Publish the MCP Registry entry under `io.github.appwrite/mcp` with `server.json` aligned to package version `0.8.4`.
- Split MCP Registry publishing into a separate release job after PyPI publish so it can be retried independently.
- Document the requirement to keep `pyproject.toml` and `server.json` release metadata in sync.

## Testing

- `actionlint .github/workflows/publish.yml`
- `git diff --check`
