### PR TITLE
Add hosted MCP icon discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ mcp-server-appwrite = "mcp_server_appwrite.__main__:main"
 
 [tool.hatch.build.targets.wheel]
 # Ship the prebuilt docs search index (non-.py package data) in the wheel.
-artifacts = ["src/mcp_server_appwrite/data/*"]
+artifacts = ["src/mcp_server_appwrite/data/*", "src/mcp_server_appwrite/assets/*"]
 
 [tool.black]
 target-version = ["py312"]

--- a/src/mcp_server_appwrite/assets/__init__.py
+++ b/src/mcp_server_appwrite/assets/__init__.py
@@ -1,0 +1,1 @@
+"""Static assets served by the hosted HTTP transport."""

--- a/src/mcp_server_appwrite/assets/favicon.svg
+++ b/src/mcp_server_appwrite/assets/favicon.svg
@@ -1,0 +1,72 @@
+<svg width="400" height="400" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g clip-path="url(#clip0_169_8784)">
+<rect width="400" height="400" fill="url(#paint0_linear_169_8784)"/>
+<g opacity="0.7" filter="url(#filter0_f_169_8784)">
+<path d="M198.621 198.621C198.621 247.374 159.098 286.896 110.345 286.896C61.5914 286.896 22.069 247.374 22.069 198.621C22.069 149.867 61.5914 110.345 110.345 110.345C159.098 110.345 198.621 149.867 198.621 198.621Z" fill="url(#paint1_radial_169_8784)"/>
+</g>
+<g opacity="0.5" filter="url(#filter1_f_169_8784)">
+<path d="M319.427 252.644V306.207H185.834C146.913 306.207 112.929 284.665 94.7473 252.644C92.1041 247.989 89.7907 243.105 87.8501 238.036C84.0407 228.102 81.6461 217.443 80.9196 206.321V191.84C81.0773 189.361 81.3258 186.902 81.6509 184.472C82.3152 179.486 83.319 174.607 84.6382 169.864C97.118 124.9 137.698 91.9541 185.834 91.9541C233.971 91.9541 274.546 124.9 287.025 169.864H229.903C220.525 155.207 204.293 145.517 185.834 145.517C167.375 145.517 151.143 155.207 141.765 169.864C138.907 174.32 136.689 179.233 135.236 184.472C133.946 189.118 133.257 194.016 133.257 199.081C133.257 214.434 139.595 228.272 149.757 238.036C159.173 247.098 171.868 252.644 185.834 252.644H319.427Z" fill="url(#paint2_linear_169_8784)"/>
+<path d="M319.427 184.472V238.036H221.912C232.074 228.273 238.411 214.434 238.411 199.081C238.411 194.016 237.723 189.118 236.433 184.472H319.427Z" fill="url(#paint3_linear_169_8784)"/>
+</g>
+<g filter="url(#filter2_ii_169_8784)">
+<path d="M319.427 252.644V306.207H185.834C146.913 306.207 112.929 284.665 94.7473 252.644C92.1041 247.989 89.7907 243.105 87.8501 238.036C84.0407 228.102 81.6461 217.443 80.9196 206.321V191.84C81.0773 189.361 81.3258 186.902 81.6509 184.472C82.3152 179.486 83.319 174.607 84.6382 169.864C97.118 124.9 137.698 91.9541 185.834 91.9541C233.971 91.9541 274.546 124.9 287.025 169.864H229.903C220.525 155.207 204.293 145.517 185.834 145.517C167.375 145.517 151.143 155.207 141.765 169.864C138.907 174.32 136.689 179.233 135.236 184.472C133.946 189.118 133.257 194.016 133.257 199.081C133.257 214.434 139.595 228.272 149.757 238.036C159.173 247.098 171.868 252.644 185.834 252.644H319.427Z" fill="url(#paint4_linear_169_8784)"/>
+<path d="M319.427 184.472V238.036H221.912C232.074 228.273 238.411 214.434 238.411 199.081C238.411 194.016 237.723 189.118 236.433 184.472H319.427Z" fill="url(#paint5_linear_169_8784)"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_f_169_8784" x="-161.839" y="-73.5633" width="544.368" height="544.368" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="91.954" result="effect1_foregroundBlur_169_8784"/>
+</filter>
+<filter id="filter1_f_169_8784" x="76.3219" y="87.3564" width="247.703" height="223.448" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="2.29885" result="effect1_foregroundBlur_169_8784"/>
+</filter>
+<filter id="filter2_ii_169_8784" x="80.9196" y="88.2759" width="238.508" height="219.77" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1.83908"/>
+<feGaussianBlur stdDeviation="1.37931"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_169_8784"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-3.67816"/>
+<feGaussianBlur stdDeviation="6.43678"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_169_8784" result="effect2_innerShadow_169_8784"/>
+</filter>
+<linearGradient id="paint0_linear_169_8784" x1="200" y1="-176.092" x2="200" y2="400" gradientUnits="userSpaceOnUse">
+<stop stop-color="#232325"/>
+<stop offset="1" stop-color="#19191C"/>
+</linearGradient>
+<radialGradient id="paint1_radial_169_8784" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(110.345 198.621) rotate(90) scale(346.945)">
+<stop stop-color="#FD366E"/>
+<stop offset="0.805" stop-color="#FE6C6A"/>
+<stop offset="1" stop-color="#1B1B1D"/>
+</radialGradient>
+<linearGradient id="paint2_linear_169_8784" x1="200.173" y1="91.9541" x2="637.701" y2="91.9541" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FD366E"/>
+<stop offset="1" stop-color="#FE9567"/>
+</linearGradient>
+<linearGradient id="paint3_linear_169_8784" x1="270.67" y1="184.472" x2="524.597" y2="227.126" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FD366E"/>
+<stop offset="1" stop-color="#FE9567"/>
+</linearGradient>
+<linearGradient id="paint4_linear_169_8784" x1="200.173" y1="91.9541" x2="776.092" y2="91.9541" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FD366E"/>
+<stop offset="1" stop-color="#FE9567"/>
+</linearGradient>
+<linearGradient id="paint5_linear_169_8784" x1="270.67" y1="184.472" x2="524.597" y2="227.126" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FD366E"/>
+<stop offset="1" stop-color="#FE9567"/>
+</linearGradient>
+<clipPath id="clip0_169_8784">
+<rect width="400" height="400" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/mcp_server_appwrite/constants.py
+++ b/src/mcp_server_appwrite/constants.py
@@ -67,7 +67,7 @@ CORS_HEADERS = {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
     "Access-Control-Allow-Headers": "Authorization, Content-Type, Mcp-Session-Id, Mcp-Protocol-Version",
-    "Access-Control-Expose-Headers": "Mcp-Session-Id, WWW-Authenticate",
+    "Access-Control-Expose-Headers": "Mcp-Session-Id, WWW-Authenticate, Link",
 }
 
 # --- operator -------------------------------------------------------------

--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -19,6 +19,7 @@ import copy
 import json
 import logging
 import sys
+from importlib.resources import files
 
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser, BearerAuthBackend
@@ -27,7 +28,7 @@ from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.responses import JSONResponse, PlainTextResponse, RedirectResponse, Response
 from starlette.routing import Route
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -35,6 +36,7 @@ from . import telemetry
 from .auth import (
     AppwriteTokenVerifier,
     protected_resource_metadata,
+    public_base_url,
     resource_metadata_url,
 )
 from .constants import CORS_HEADERS, SERVER_VERSION
@@ -69,6 +71,18 @@ def _is_valid_scope_token(scope: str) -> bool:
         char == "\x21" or "\x23" <= char <= "\x5b" or "\x5d" <= char <= "\x7e"
         for char in scope
     )
+
+
+def _icon_url() -> str:
+    return f"{public_base_url()}/favicon.svg"
+
+
+def _icon_link_header() -> str:
+    return f'<{_icon_url()}>; rel="icon"; type="image/svg+xml"'
+
+
+def _icon_svg() -> bytes:
+    return files("mcp_server_appwrite.assets").joinpath("favicon.svg").read_bytes()
 
 
 async def _send_401(send: Send) -> None:
@@ -106,6 +120,7 @@ async def _send_401(send: Send) -> None:
         (b"content-type", b"application/json"),
         (b"content-length", str(len(body)).encode()),
         (b"www-authenticate", www_authenticate.encode()),
+        (b"link", _icon_link_header().encode()),
     ]
     await send({"type": "http.response.start", "status": 401, "headers": headers})
     await send({"type": "http.response.body", "body": body})
@@ -157,11 +172,24 @@ def _has_authorization_header(scope: Scope) -> bool:
 
 async def protected_resource_metadata_endpoint(request: Request) -> JSONResponse:
     metadata = await protected_resource_metadata()
-    return JSONResponse(metadata, headers=CORS_HEADERS)
+    headers = {**CORS_HEADERS, "Link": _icon_link_header()}
+    return JSONResponse(metadata, headers=headers)
 
 
 async def health_endpoint(request: Request) -> PlainTextResponse:
     return PlainTextResponse(f"appwrite-mcp {SERVER_VERSION} ok")
+
+
+async def favicon_svg_endpoint(request: Request) -> Response:
+    return Response(
+        _icon_svg(),
+        media_type="image/svg+xml",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+async def favicon_ico_endpoint(request: Request) -> RedirectResponse:
+    return RedirectResponse("/favicon.svg", status_code=307)
 
 
 def build_app() -> Starlette:
@@ -195,6 +223,8 @@ def build_app() -> Starlette:
             endpoint=protected_resource_metadata_endpoint,
             methods=["GET", "OPTIONS"],
         ),
+        Route("/favicon.svg", endpoint=favicon_svg_endpoint, methods=["GET"]),
+        Route("/favicon.ico", endpoint=favicon_ico_endpoint, methods=["GET"]),
         Route("/healthz", endpoint=health_endpoint, methods=["GET"]),
         Route(
             "/mcp",

--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -28,7 +28,12 @@ from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, PlainTextResponse, RedirectResponse, Response
+from starlette.responses import (
+    JSONResponse,
+    PlainTextResponse,
+    RedirectResponse,
+    Response,
+)
 from starlette.routing import Route
 from starlette.types import ASGIApp, Receive, Scope, Send
 


### PR DESCRIPTION
## Summary
- add packaged SVG icon asset for the hosted MCP HTTP server
- serve `/favicon.svg` and redirect `/favicon.ico` to it
- advertise the icon with `Link: rel="icon"` on auth challenge and protected-resource metadata responses
- expose `Link` via CORS so browser-based clients can read it

## Verification
- Confirmed the SVG asset is lightweight and does not contain embedded raster/base64 image data
- No tests run per request
