### PR TITLE
Fix docs search diagnostics and bump 0.8.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-appwrite"
-version = "0.8.5"
+version = "0.8.6"
 description = "MCP (Model Context Protocol) server for Appwrite"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.appwrite/mcp",
   "description": "MCP (Model Context Protocol) server for Appwrite",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "repository": {
     "url": "https://github.com/appwrite/mcp",
     "source": "github"
@@ -15,7 +15,7 @@
   ],
   "packages": [
     {
-      "version": "0.8.5",
+      "version": "0.8.6",
       "registryType": "pypi",
       "identifier": "mcp-server-appwrite",
       "transport": {

--- a/src/mcp_server_appwrite/constants.py
+++ b/src/mcp_server_appwrite/constants.py
@@ -14,7 +14,7 @@ from appwrite.models.user import User
 
 # --- server ---------------------------------------------------------------
 
-SERVER_VERSION = "0.8.4"
+SERVER_VERSION = "0.8.6"
 
 DEFAULT_ENDPOINT = "https://cloud.appwrite.io/v1"
 # Region reported by single-region deployments; carries no region subdomain.

--- a/src/mcp_server_appwrite/docs_search.py
+++ b/src/mcp_server_appwrite/docs_search.py
@@ -45,6 +45,9 @@ def _default_embedder() -> Embedder | None:
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         return None
+    api_key = "".join(api_key.split())
+    if not api_key:
+        return None
 
     from openai import OpenAI
 
@@ -158,7 +161,14 @@ class DocsSearch:
             )
 
         limit = _clamp_limit(arguments.get("limit"), self._default_limit)
-        results, embedding_duration_s = self._rank(query, limit)
+        try:
+            results, embedding_duration_s = self._rank(query, limit)
+        except Exception as exc:
+            telemetry.record_search_docs(outcome="error", match_count=0)
+            raise RuntimeError(
+                "Documentation search embedding request failed. "
+                "Check OPENAI_API_KEY and outbound connectivity to OpenAI."
+            ) from exc
         telemetry.record_search_docs(
             outcome="success",
             match_count=len(results),

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ cli = [
 
 [[package]]
 name = "mcp-server-appwrite"
-version = "0.8.5"
+version = "0.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "appwrite" },


### PR DESCRIPTION
## Summary
- sanitize whitespace from `OPENAI_API_KEY` before creating the OpenAI docs-search embedder
- surface docs-search embedding failures with clearer diagnostics and error telemetry
- bump package, server registry metadata, lockfile, and runtime server version to `0.8.6`

## Testing
- `uv run python -m unittest tests.unit.test_docs_search -v`
- `uv run python -m unittest tests.unit.test_operator -v`
- `uv run --group dev ruff check src tests`
- `uv run --group dev black --check src tests`
- `uv run --group dev pyright`
