### PR TITLE
Clean up unused MCP telemetry metrics

### DIFF
--- a/src/mcp_server_appwrite/operator.py
+++ b/src/mcp_server_appwrite/operator.py
@@ -504,7 +504,6 @@ class Operator:
             stored_result = self._result_store.save(
                 tool_name, content, _serialize_content(content)
             )
-            telemetry.record_result_stored(tool_name)
             preview = full_text[: self._preview_threshold]
             return [
                 types.TextContent(
@@ -519,7 +518,6 @@ class Operator:
         stored_result = self._result_store.save(
             tool_name, content, _serialize_content(content)
         )
-        telemetry.record_result_stored(tool_name)
         summary = ", ".join(_summarize_content_item(item) for item in content)
         return [
             types.TextContent(

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -380,21 +380,18 @@ def validate_services(tools_manager: ToolManager) -> None:
     try:
         _validate_service(service)
     except AppwriteException as exc:
-        telemetry.record_startup_validation(service.service_name, "error")
         raise RuntimeError(
             "Appwrite startup validation failed during the minimal startup probe. "
             "Check your endpoint, project ID, API key, and required scopes.\n"
             f"- {service.service_name}: {_format_appwrite_error(exc)}"
         ) from exc
     except Exception as exc:
-        telemetry.record_startup_validation(service.service_name, "error")
         raise RuntimeError(
             "Appwrite startup validation failed during the minimal startup probe. "
             "Check your endpoint, project ID, API key, and required scopes.\n"
             f"- {service.service_name}: {exc}"
         ) from exc
 
-    telemetry.record_startup_validation(service.service_name, "success")
     _log_startup(f"Validated startup access via {service.service_name}")
 
 

--- a/src/mcp_server_appwrite/telemetry.py
+++ b/src/mcp_server_appwrite/telemetry.py
@@ -136,7 +136,7 @@ def _build_instruments(meter: Any, transport: str, version: str) -> None:
     _instruments["requests"] = meter.create_counter(
         "mcp.requests",
         unit="{request}",
-        description="MCP JSON-RPC requests handled.",
+        description="Instrumented MCP JSON-RPC handler calls.",
     )
     _instruments["request_duration"] = meter.create_histogram(
         "mcp.request.duration",
@@ -208,11 +208,6 @@ def _build_instruments(meter: Any, transport: str, version: str) -> None:
         unit="s",
         description="Bearer-token verification duration.",
     )
-    _instruments["results_stored"] = meter.create_counter(
-        "mcp.results.stored",
-        unit="{result}",
-        description="Large tool results spilled to MCP resources.",
-    )
     _instruments["resources_reads"] = meter.create_counter(
         "mcp.resources.reads",
         unit="{read}",
@@ -233,12 +228,6 @@ def _build_instruments(meter: Any, transport: str, version: str) -> None:
         unit="{error}",
         description="File upload failures.",
     )
-    _instruments["startup_validation"] = meter.create_counter(
-        "mcp.startup.validation",
-        unit="{probe}",
-        description="Startup service-validation probe outcomes.",
-    )
-
     # Observable gauges: distinct active users/clients over a rolling window, and a
     # build-info gauge (always 1, carries version/transport labels).
     meter.create_observable_gauge(
@@ -480,10 +469,6 @@ def record_auth(
         _safe_record("auth_duration", duration_s, {"outcome": outcome})
 
 
-def record_result_stored(tool_name: str) -> None:
-    _safe_add("results_stored", 1, {"tool.name": tool_name})
-
-
 def record_resource_read(resource_type: str) -> None:
     _safe_add("resources_reads", 1, {"resource.type": resource_type})
 
@@ -496,7 +481,3 @@ def record_upload(*, source: str, outcome: str, size_bytes: int | None = None) -
 
 def record_upload_error(reason: str) -> None:
     _safe_add("upload_errors", 1, {"reason": reason})
-
-
-def record_startup_validation(service: str, outcome: str) -> None:
-    _safe_add("startup_validation", 1, {"service": service, "outcome": outcome})


### PR DESCRIPTION
## Summary
- remove hosted telemetry instruments that cannot emit useful data (`mcp.results.stored`, `mcp.startup.validation`)
- remove the corresponding record calls from result storage and stdio startup validation paths
- clarify that `mcp.requests` counts instrumented MCP handlers, not raw HTTP traffic

## Validation
- `uv run --group dev ruff check src tests`
- `uv run --group dev black --check src tests`
- `uv run --group dev pyright`
- `uv run python -m unittest discover -s tests/unit -v`

## Notes
- No related issue.
