### PR TITLE
Filter expected MCP errors from Sentry

### DIFF
--- a/src/mcp_server_appwrite/error_monitoring.py
+++ b/src/mcp_server_appwrite/error_monitoring.py
@@ -216,7 +216,52 @@ def _before_send(event: Any, hint: Any) -> Any:
         exc = exc_info[1]
         if isinstance(exc, BaseException) and not _should_capture(exc):
             return None
-    return _sanitize(event)
+    return _normalize_transaction(_sanitize(event))
+
+
+def _normalize_transaction(event: Any) -> Any:
+    if not isinstance(event, dict):
+        return event
+
+    transaction = event.get("transaction")
+    if isinstance(transaction, str) and transaction.startswith(("mcp.", "appwrite.")):
+        return event
+
+    tags = _event_tags(event)
+    method = tags.get("mcp.method")
+    if not method:
+        return event
+
+    if method == "tools/call":
+        tool_name = tags.get("tool.name")
+        event["transaction"] = (
+            f"mcp.tools/call:{tool_name}" if tool_name else "mcp.tools/call"
+        )
+    elif method in {"tools/list", "resources/list"}:
+        event["transaction"] = f"mcp.{method}"
+    elif method == "resources/read":
+        resource_type = tags.get("resource.type")
+        event["transaction"] = (
+            f"mcp.resources/read:{resource_type}"
+            if resource_type
+            else "mcp.resources/read"
+        )
+
+    return event
+
+
+def _event_tags(event: dict[str, Any]) -> dict[str, str]:
+    raw_tags = event.get("tags", {})
+    if isinstance(raw_tags, dict):
+        return {str(key): str(value) for key, value in raw_tags.items()}
+    if isinstance(raw_tags, list):
+        return {
+            str(key): str(value)
+            for item in raw_tags
+            if isinstance(item, (list, tuple)) and len(item) == 2
+            for key, value in [item]
+        }
+    return {}
 
 
 def _sanitize(value: Any) -> Any:

--- a/src/mcp_server_appwrite/error_monitoring.py
+++ b/src/mcp_server_appwrite/error_monitoring.py
@@ -158,7 +158,7 @@ def capture_appwrite_exception(
 def _should_capture(exc: BaseException) -> bool:
     if _already_captured(exc):
         return False
-    if isinstance(exc, ValueError):
+    if _find_exception(exc, ValueError) is not None:
         return False
     appwrite_error = _find_appwrite_exception(exc)
     if appwrite_error is not None and _is_appwrite_client_error(appwrite_error):
@@ -167,11 +167,18 @@ def _should_capture(exc: BaseException) -> bool:
 
 
 def _find_appwrite_exception(exc: BaseException) -> AppwriteException | None:
+    found = _find_exception(exc, AppwriteException)
+    return found if isinstance(found, AppwriteException) else None
+
+
+def _find_exception(
+    exc: BaseException, exc_type: type[BaseException]
+) -> BaseException | None:
     current: BaseException | None = exc
     seen: set[int] = set()
     while current is not None and id(current) not in seen:
         seen.add(id(current))
-        if isinstance(current, AppwriteException):
+        if isinstance(current, exc_type):
             return current
         current = current.__cause__ or current.__context__
     return None
@@ -204,6 +211,11 @@ def _mark_captured(exc: BaseException) -> None:
 
 
 def _before_send(event: Any, hint: Any) -> Any:
+    exc_info = hint.get("exc_info") if isinstance(hint, Mapping) else None
+    if isinstance(exc_info, tuple) and len(exc_info) >= 2:
+        exc = exc_info[1]
+        if isinstance(exc, BaseException) and not _should_capture(exc):
+            return None
     return _sanitize(event)
 
 

--- a/src/mcp_server_appwrite/error_monitoring.py
+++ b/src/mcp_server_appwrite/error_monitoring.py
@@ -158,7 +158,7 @@ def capture_appwrite_exception(
 def _should_capture(exc: BaseException) -> bool:
     if _already_captured(exc):
         return False
-    if _find_exception(exc, ValueError) is not None:
+    if isinstance(exc, ValueError):
         return False
     appwrite_error = _find_appwrite_exception(exc)
     if appwrite_error is not None and _is_appwrite_client_error(appwrite_error):

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -1024,10 +1024,21 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
                 error_code=_jsonrpc_error_code(exc),
                 error_message=type(exc).__name__,
             )
+            mcp_context = _mcp_request_context(server)
             error_monitoring.capture_exception(
                 exc,
-                tags={"mcp.method": "tools/list", "transport": transport},
-                context={"mcp": {"method": "tools/list", "transport": transport}},
+                tags={
+                    "mcp.method": "tools/list",
+                    "transport": transport,
+                    **mcp_context.tags,
+                },
+                context={
+                    "mcp": {
+                        "method": "tools/list",
+                        "transport": transport,
+                        **mcp_context.context,
+                    }
+                },
                 transaction="mcp.tools/list",
             )
             raise
@@ -1055,12 +1066,14 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
                 error_code=_jsonrpc_error_code(exc),
                 error_message=type(exc).__name__,
             )
+            mcp_context = _mcp_request_context(server)
             error_monitoring.capture_exception(
                 exc,
                 tags={
                     "mcp.method": "tools/call",
                     "tool.name": name,
                     "transport": transport,
+                    **mcp_context.tags,
                     **_target_context_tags(arguments),
                 },
                 context={
@@ -1068,6 +1081,7 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
                         "method": "tools/call",
                         "tool_name": name,
                         "transport": transport,
+                        **mcp_context.context,
                     },
                     "appwrite": _target_context(arguments),
                 },
@@ -1091,10 +1105,21 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
                 error_code=_jsonrpc_error_code(exc),
                 error_message=type(exc).__name__,
             )
+            mcp_context = _mcp_request_context(server)
             error_monitoring.capture_exception(
                 exc,
-                tags={"mcp.method": "resources/list", "transport": transport},
-                context={"mcp": {"method": "resources/list", "transport": transport}},
+                tags={
+                    "mcp.method": "resources/list",
+                    "transport": transport,
+                    **mcp_context.tags,
+                },
+                context={
+                    "mcp": {
+                        "method": "resources/list",
+                        "transport": transport,
+                        **mcp_context.context,
+                    }
+                },
                 transaction="mcp.resources/list",
             )
             raise
@@ -1128,18 +1153,21 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
                 error_code=_jsonrpc_error_code(exc),
                 error_message=type(exc).__name__,
             )
+            mcp_context = _mcp_request_context(server)
             error_monitoring.capture_exception(
                 exc,
                 tags={
                     "mcp.method": "resources/read",
                     "resource.type": resource_type,
                     "transport": transport,
+                    **mcp_context.tags,
                 },
                 context={
                     "mcp": {
                         "method": "resources/read",
                         "resource_type": resource_type,
                         "transport": transport,
+                        **mcp_context.context,
                     },
                 },
                 transaction=f"mcp.resources/read:{resource_type}",
@@ -1163,6 +1191,50 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
 
 def _jsonrpc_error_code(exc: Exception) -> int:
     return -32602 if isinstance(exc, ValueError) else -32603
+
+
+@dataclass(frozen=True)
+class McpRequestContext:
+    tags: dict[str, Any]
+    context: dict[str, Any]
+
+
+def _mcp_request_context(server: Server) -> McpRequestContext:
+    try:
+        params = server.request_context.session.client_params
+    except Exception:
+        return McpRequestContext(tags={}, context={})
+    if params is None:
+        return McpRequestContext(tags={}, context={})
+
+    client_info = getattr(params, "clientInfo", None)
+    client_name = getattr(client_info, "name", None)
+    client_version = getattr(client_info, "version", None)
+    protocol_version = getattr(params, "protocolVersion", None)
+
+    tags = {
+        key: value
+        for key, value in {
+            "mcp.client.name": client_name,
+            "mcp.client.version": client_version,
+            "mcp.protocol_version": protocol_version,
+        }.items()
+        if value is not None
+    }
+    context = {
+        "client": {
+            key: value
+            for key, value in {
+                "name": client_name,
+                "version": client_version,
+                "protocol_version": protocol_version,
+            }.items()
+            if value is not None
+        }
+    }
+    if not context["client"]:
+        context = {}
+    return McpRequestContext(tags=tags, context=context)
 
 
 def _target_context(arguments: dict | None) -> dict[str, Any]:

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -959,7 +959,10 @@ def _format_appwrite_error(exc: AppwriteException) -> str:
     if getattr(exc, "type", None):
         details.append(f"type={exc.type}")
     detail_text = f" ({', '.join(details)})" if details else ""
-    return f"Appwrite request failed{detail_text}: {exc}"
+    message = str(exc).replace("\n", " ").strip()
+    if len(message) > 500:
+        message = f"{message[:500]}..."
+    return f"Appwrite request failed{detail_text}: {message}"
 
 
 def build_instructions(transport: str = "http") -> str:

--- a/tests/unit/test_error_monitoring.py
+++ b/tests/unit/test_error_monitoring.py
@@ -52,6 +52,19 @@ class ErrorMonitoringTests(unittest.TestCase):
         self.assertFalse(captured)
         capture.assert_not_called()
 
+    def test_wrapped_value_errors_are_not_captured(self):
+        error_monitoring._enabled = True
+        with patch("sentry_sdk.capture_exception") as capture:
+            try:
+                raise ValueError("bad input")
+            except ValueError as exc:
+                wrapped = RuntimeError("wrapped")
+                wrapped.__cause__ = exc
+                captured = error_monitoring.capture_exception(wrapped)
+
+        self.assertFalse(captured)
+        capture.assert_not_called()
+
     def test_appwrite_4xx_errors_are_not_captured(self):
         error_monitoring._enabled = True
         exc = AppwriteException("missing scope", 401, "general_unauthorized_scope")
@@ -63,6 +76,19 @@ class ErrorMonitoringTests(unittest.TestCase):
                 action="list",
                 classification="read",
             )
+
+        self.assertFalse(captured)
+        capture.assert_not_called()
+
+    def test_wrapped_appwrite_4xx_errors_are_not_captured(self):
+        error_monitoring._enabled = True
+        exc = AppwriteException("not found", 404, "user_target_not_found")
+
+        with patch("sentry_sdk.capture_exception") as capture:
+            try:
+                raise RuntimeError("wrapped") from exc
+            except RuntimeError as wrapped:
+                captured = error_monitoring.capture_exception(wrapped)
 
         self.assertFalse(captured)
         capture.assert_not_called()
@@ -202,6 +228,17 @@ class ErrorMonitoringTests(unittest.TestCase):
         self.assertEqual(scrubbed["request"]["data"], "[Filtered]")
         self.assertEqual(scrubbed["extra"]["password"], "[Filtered]")
         self.assertEqual(scrubbed["extra"]["safe"], "ok")
+
+    def test_before_send_drops_expected_exception_chains(self):
+        appwrite_error = AppwriteException("not found", 404, "not_found")
+        wrapped = RuntimeError("wrapped")
+        wrapped.__cause__ = appwrite_error
+
+        self.assertIsNone(
+            error_monitoring._before_send(
+                {"event_id": "1"}, {"exc_info": (RuntimeError, wrapped, None)}
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_error_monitoring.py
+++ b/tests/unit/test_error_monitoring.py
@@ -52,18 +52,28 @@ class ErrorMonitoringTests(unittest.TestCase):
         self.assertFalse(captured)
         capture.assert_not_called()
 
-    def test_wrapped_value_errors_are_not_captured(self):
+    def test_wrapped_value_errors_are_captured(self):
         error_monitoring._enabled = True
-        with patch("sentry_sdk.capture_exception") as capture:
-            try:
-                raise ValueError("bad input")
-            except ValueError as exc:
-                wrapped = RuntimeError("wrapped")
-                wrapped.__cause__ = exc
-                captured = error_monitoring.capture_exception(wrapped)
 
-        self.assertFalse(captured)
-        capture.assert_not_called()
+        class FakeScope:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        scope = FakeScope()
+        with patch("sentry_sdk.capture_exception") as capture:
+            with patch("sentry_sdk.new_scope", return_value=scope):
+                try:
+                    raise ValueError("bad input")
+                except ValueError as exc:
+                    wrapped = RuntimeError("wrapped")
+                    wrapped.__cause__ = exc
+                    captured = error_monitoring.capture_exception(wrapped)
+
+        self.assertTrue(captured)
+        capture.assert_called_once_with(wrapped)
 
     def test_appwrite_4xx_errors_are_not_captured(self):
         error_monitoring._enabled = True

--- a/tests/unit/test_error_monitoring.py
+++ b/tests/unit/test_error_monitoring.py
@@ -240,6 +240,42 @@ class ErrorMonitoringTests(unittest.TestCase):
             )
         )
 
+    def test_before_send_normalizes_mcp_tool_call_transaction(self):
+        event = {
+            "transaction": "http://10.140.28.8:8000/mcp",
+            "tags": {
+                "mcp.method": "tools/call",
+                "tool.name": "appwrite_call_tool",
+            },
+        }
+
+        scrubbed = error_monitoring._before_send(event, {})
+
+        self.assertEqual(scrubbed["transaction"], "mcp.tools/call:appwrite_call_tool")
+
+    def test_before_send_normalizes_mcp_resource_transaction_from_list_tags(self):
+        event = {
+            "transaction": "http://10.140.28.8:8000/mcp",
+            "tags": [
+                ["mcp.method", "resources/read"],
+                ["resource.type", "result"],
+            ],
+        }
+
+        scrubbed = error_monitoring._before_send(event, {})
+
+        self.assertEqual(scrubbed["transaction"], "mcp.resources/read:result")
+
+    def test_before_send_keeps_explicit_semantic_transaction(self):
+        event = {
+            "transaction": "appwrite.users.list",
+            "tags": {"mcp.method": "tools/call", "tool.name": "appwrite_call_tool"},
+        }
+
+        scrubbed = error_monitoring._before_send(event, {})
+
+        self.assertEqual(scrubbed["transaction"], "appwrite.users.list")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -19,6 +19,7 @@ from mcp_server_appwrite.server import (
     _coerce_argument,
     _configure_uploads,
     _execute_public_tool_for_transport,
+    _format_appwrite_error,
     _format_tool_result,
     _prepare_arguments,
     _validate_service,
@@ -348,6 +349,15 @@ class ServerHelperTests(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertIsInstance(result[0], types.EmbeddedResource)
         self.assertEqual(result[0].resource.mimeType, "application/octet-stream")
+
+    def test_format_appwrite_error_truncates_large_html_body(self):
+        exc = AppwriteException("<!DOCTYPE html>" + ("x" * 1000), 404, None)
+
+        message = _format_appwrite_error(exc)
+
+        self.assertIn("code=404", message)
+        self.assertLess(len(message), 560)
+        self.assertTrue(message.endswith("..."))
 
     def test_register_services_returns_fresh_manager(self):
         manager_a = register_services(object())

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -21,6 +21,7 @@ from mcp_server_appwrite.server import (
     _execute_public_tool_for_transport,
     _format_appwrite_error,
     _format_tool_result,
+    _mcp_request_context,
     _prepare_arguments,
     _validate_service,
     build_client,
@@ -358,6 +359,51 @@ class ServerHelperTests(unittest.TestCase):
         self.assertIn("code=404", message)
         self.assertLess(len(message), 560)
         self.assertTrue(message.endswith("..."))
+
+    def test_mcp_request_context_extracts_client_metadata(self):
+        server = Mock()
+        server.request_context.session.client_params = type(
+            "Params",
+            (),
+            {
+                "clientInfo": type(
+                    "ClientInfo",
+                    (),
+                    {"name": "codex", "version": "1.2.3"},
+                )(),
+                "protocolVersion": "2025-06-18",
+            },
+        )()
+
+        context = _mcp_request_context(server)
+
+        self.assertEqual(
+            context.tags,
+            {
+                "mcp.client.name": "codex",
+                "mcp.client.version": "1.2.3",
+                "mcp.protocol_version": "2025-06-18",
+            },
+        )
+        self.assertEqual(
+            context.context,
+            {
+                "client": {
+                    "name": "codex",
+                    "version": "1.2.3",
+                    "protocol_version": "2025-06-18",
+                }
+            },
+        )
+
+    def test_mcp_request_context_tolerates_missing_client_metadata(self):
+        server = Mock()
+        server.request_context.session.client_params = None
+
+        context = _mcp_request_context(server)
+
+        self.assertEqual(context.tags, {})
+        self.assertEqual(context.context, {})
 
     def test_register_services_returns_fresh_manager(self):
         manager_a = register_services(object())


### PR DESCRIPTION
## Summary
- filter expected wrapped MCP input errors and Appwrite 4xx chains out of Sentry capture
- apply the same filtering in Sentry `before_send` for integration-captured handled exceptions
- truncate very large Appwrite error bodies before returning MCP error text

## Tests
- `uv run --group dev ruff check src tests`
- `uv run --group dev black --check src tests`
- `uv run --group dev pyright`
- `uv run python -m unittest discover -s tests/unit -v`
