### PR TITLE
Emit MCP Server Observability reference-dashboard metric set

### DIFF
--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -19,6 +19,7 @@ import copy
 import json
 import logging
 import sys
+import time
 from importlib.resources import files
 
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
@@ -157,6 +158,12 @@ class RequireBearer:
             # don't double-count rejections.
             if not _has_authorization_header(scope):
                 telemetry.record_auth(outcome="rejected", reason="missing")
+            else:
+                # A token was presented and rejected — this session never
+                # completes its MCP handshake. Unauthenticated discovery probes
+                # (no token at all) are part of the normal OAuth flow and are
+                # not counted as handshake failures.
+                telemetry.record_handshake_failure(reason="invalid_token")
             await _send_401(send)
             return
 
@@ -173,6 +180,49 @@ def _has_authorization_header(scope: Scope) -> bool:
         if name == b"authorization":
             return True
     return False
+
+
+_KNOWN_HANDLERS = {
+    "/mcp",
+    "/healthz",
+    "/favicon.svg",
+    "/favicon.ico",
+    "/.well-known/oauth-protected-resource/mcp",
+}
+
+
+class HTTPMetricsMiddleware:
+    """Outermost ASGI wrapper emitting ``http.requests`` / ``http.request.duration``.
+
+    The handler label is the raw path for the fixed route table above and
+    ``other`` for everything else, so unmatched scanner paths cannot explode
+    label cardinality."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":  # pragma: no cover
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        handler = path if path in _KNOWN_HANDLERS else "other"
+        method = scope.get("method", "GET")
+        start = time.monotonic()
+        status_holder = {"status": 500}
+
+        async def send_wrapper(message) -> None:
+            if message["type"] == "http.response.start":
+                status_holder["status"] = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            telemetry.record_http_request(
+                handler, method, status_holder["status"], time.monotonic() - start
+            )
 
 
 async def protected_resource_metadata_endpoint(request: Request) -> JSONResponse:
@@ -240,6 +290,7 @@ def build_app() -> Starlette:
     ]
 
     middleware = [
+        Middleware(HTTPMetricsMiddleware),
         Middleware(
             AuthenticationMiddleware, backend=BearerAuthBackend(AppwriteTokenVerifier())
         ),

--- a/src/mcp_server_appwrite/operator.py
+++ b/src/mcp_server_appwrite/operator.py
@@ -274,14 +274,27 @@ class Operator:
         self, name: str, arguments: dict[str, Any] | None
     ) -> list[ToolContent]:
         start = time.monotonic()
-        outcome = "success"
+        status = "success"
+        error_type: str | None = None
+        output_chars = 0
+        telemetry.tool_call_started(name)
         try:
-            return self._dispatch_public_tool(name, arguments)
-        except Exception:
-            outcome = "error"
+            result = self._dispatch_public_tool(name, arguments)
+            output_chars = _content_size(result)
+            return result
+        except Exception as exc:
+            status = "error"
+            error_type = type(exc).__name__
             raise
         finally:
-            telemetry.record_tool_call(name, outcome, time.monotonic() - start)
+            telemetry.record_tool_call(
+                name,
+                status,
+                time.monotonic() - start,
+                error_type=error_type,
+                input_chars=len(json.dumps(arguments)) if arguments else 0,
+                output_chars=output_chars,
+            )
 
     def _dispatch_public_tool(
         self, name: str, arguments: dict[str, Any] | None
@@ -463,6 +476,7 @@ class Operator:
 
         entry = self._catalog_map.get(tool_name)
         if not entry:
+            telemetry.record_hallucination(tool_name)
             raise ValueError(
                 f"Tool {tool_name} was not found. Use appwrite_search_tools first."
             )
@@ -771,6 +785,20 @@ def _normalize_arguments(raw_arguments: dict[str, Any]) -> dict[str, Any]:
             merged_arguments[key] = value
 
     return merged_arguments
+
+
+def _content_size(content: list[ToolContent]) -> int:
+    total = 0
+    for item in content:
+        if isinstance(item, types.TextContent):
+            total += len(item.text)
+        elif isinstance(item, types.ImageContent):
+            total += len(item.data)
+        else:
+            text = getattr(item.resource, "text", None)
+            blob = getattr(item.resource, "blob", None)
+            total += len(text or blob or "")
+    return total
 
 
 def _serialize_content(content: list[ToolContent]) -> str:

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -811,6 +811,8 @@ def execute_registered_tool(
             error_code=getattr(exc, "code", None),
             error_type=getattr(exc, "type", None),
         )
+        if getattr(exc, "code", None) == 429:
+            telemetry.record_rate_limit(name)
         error_monitoring.capture_appwrite_exception(
             exc,
             service=parsed["service_name"],
@@ -1012,7 +1014,13 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
         try:
             result = operator.get_public_tools()
         except Exception as exc:
-            telemetry.record_request("tools/list", "error", time.monotonic() - start)
+            telemetry.record_message(
+                "tools/list",
+                "error",
+                time.monotonic() - start,
+                error_code=_jsonrpc_error_code(exc),
+                error_message=type(exc).__name__,
+            )
             error_monitoring.capture_exception(
                 exc,
                 tags={"mcp.method": "tools/list", "transport": transport},
@@ -1020,7 +1028,7 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
                 transaction="mcp.tools/list",
             )
             raise
-        telemetry.record_request("tools/list", "success", time.monotonic() - start)
+        telemetry.record_message("tools/list", "success", time.monotonic() - start)
         return result
 
     @server.call_tool()
@@ -1031,12 +1039,19 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
         start = time.monotonic()
         try:
             if not operator.has_public_tool(name):
+                telemetry.record_hallucination(name)
                 raise ValueError(f"Tool {name} not found")
             result = await _execute_public_tool_for_transport(
                 operator, name, arguments, transport
             )
         except Exception as exc:
-            telemetry.record_request("tools/call", "error", time.monotonic() - start)
+            telemetry.record_message(
+                "tools/call",
+                "error",
+                time.monotonic() - start,
+                error_code=_jsonrpc_error_code(exc),
+                error_message=type(exc).__name__,
+            )
             error_monitoring.capture_exception(
                 exc,
                 tags={
@@ -1056,17 +1071,22 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
                 transaction=f"mcp.tools/call:{name}",
             )
             raise
-        telemetry.record_request("tools/call", "success", time.monotonic() - start)
+        telemetry.record_message("tools/call", "success", time.monotonic() - start)
         return result
 
     @server.list_resources()
     async def handle_list_resources() -> list[types.Resource]:
+        _emit_initialize(server)
         start = time.monotonic()
         try:
             result = operator.list_resources()
         except Exception as exc:
-            telemetry.record_request(
-                "resources/list", "error", time.monotonic() - start
+            telemetry.record_message(
+                "resources/list",
+                "error",
+                time.monotonic() - start,
+                error_code=_jsonrpc_error_code(exc),
+                error_message=type(exc).__name__,
             )
             error_monitoring.capture_exception(
                 exc,
@@ -1075,7 +1095,7 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
                 transaction="mcp.resources/list",
             )
             raise
-        telemetry.record_request("resources/list", "success", time.monotonic() - start)
+        telemetry.record_message("resources/list", "success", time.monotonic() - start)
         return result
 
     @server.list_resource_templates()
@@ -1084,15 +1104,26 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
 
     @server.read_resource()
     async def handle_read_resource(uri) -> list[ReadResourceContents]:
+        _emit_initialize(server)
         start = time.monotonic()
         uri_str = str(uri)
         resource_type = "catalog" if uri_str == CATALOG_URI else "result"
-        telemetry.record_resource_read(resource_type)
         try:
             result = operator.read_resource(uri_str)
         except Exception as exc:
-            telemetry.record_request(
-                "resources/read", "error", time.monotonic() - start
+            telemetry.record_resource_access(
+                resource_type,
+                outcome="error",
+                anomaly=(
+                    "unknown_resource" if isinstance(exc, ValueError) else "read_error"
+                ),
+            )
+            telemetry.record_message(
+                "resources/read",
+                "error",
+                time.monotonic() - start,
+                error_code=_jsonrpc_error_code(exc),
+                error_message=type(exc).__name__,
             )
             error_monitoring.capture_exception(
                 exc,
@@ -1111,10 +1142,24 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
                 transaction=f"mcp.resources/read:{resource_type}",
             )
             raise
-        telemetry.record_request("resources/read", "success", time.monotonic() - start)
+        size_bytes = sum(
+            (
+                len(item.content)
+                if isinstance(item.content, bytes)
+                else len(str(item.content).encode("utf-8"))
+            )
+            for item in result
+        )
+        telemetry.record_resource_access(resource_type, size_bytes=size_bytes)
+        telemetry.record_message_size("sent", size_bytes)
+        telemetry.record_message("resources/read", "success", time.monotonic() - start)
         return result
 
     return server
+
+
+def _jsonrpc_error_code(exc: Exception) -> int:
+    return -32602 if isinstance(exc, ValueError) else -32603
 
 
 def _target_context(arguments: dict | None) -> dict[str, Any]:
@@ -1163,9 +1208,10 @@ async def _execute_public_tool_for_transport(
 
 
 def _emit_initialize(server: Server) -> None:
-    """Emit an ``mcp.initializations`` event and refresh active-user/client tracking
-    for the current session. Deduped per session in the telemetry layer. Best-effort:
-    any failure to read the request context is swallowed."""
+    """Bind the current session's client/user identity to the request context and
+    emit an ``mcp.connection`` + ``mcp.handshake`` event (deduped per session in the
+    telemetry layer). Best-effort: any failure to read the request context is
+    swallowed."""
     try:
         session = server.request_context.session
         params = session.client_params
@@ -1175,23 +1221,20 @@ def _emit_initialize(server: Server) -> None:
         return
 
     client_info = getattr(params, "clientInfo", None)
-    oauth_client_id = None
     subject = None
     try:
         access_token = get_access_token()
         if access_token is not None:
             claims = access_token.claims or {}
-            oauth_client_id = claims.get("client_id") or claims.get("azp")
             subject = access_token.subject or claims.get("sub")
     except Exception:
         pass
 
-    telemetry.record_initialize(
+    telemetry.record_connection(
         session_id=id(session),
         client_name=getattr(client_info, "name", None),
         client_version=getattr(client_info, "version", None),
         protocol_version=getattr(params, "protocolVersion", None),
-        oauth_client_id=oauth_client_id,
         subject=subject,
     )
 

--- a/src/mcp_server_appwrite/telemetry.py
+++ b/src/mcp_server_appwrite/telemetry.py
@@ -5,6 +5,13 @@ services: it exports OpenTelemetry metrics over OTLP/HTTP to an OpenTelemetry
 Collector, which forwards them to the shared Prometheus/Mimir + Grafana stack
 (``telemetry.appwrite.systems``).
 
+The metric names follow the "MCP Server Observability" reference dashboard
+(grafana.com/grafana/dashboards/25252): after the standard OTLP-to-Prometheus
+translation (dots become underscores, unit and ``_total`` suffixes appended)
+the instruments below land as ``mcp_tool_calls_total``,
+``mcp_tool_duration_seconds_bucket``, ``mcp_active_sessions``,
+``http_requests_total``, and so on.
+
 Design notes:
 
 * **No-op by default.** Like the PHP ``None``/``NoTelemetry`` adapter, the module
@@ -14,9 +21,14 @@ Design notes:
 * **Exception-safe.** Every ``record_*`` helper swallows its own errors —
   telemetry must never break a request.
 * **Cardinality-disciplined.** No user id (``sub``), token, raw query text, file
-  name, result id, or IP is ever used as a metric attribute. Distinct-user and
-  distinct-client counts are derived in-process from rolling TTL sets and exposed
-  only as aggregate gauges.
+  name, result id, or IP is ever used as a metric attribute. ``client_id`` is the
+  MCP client *name* (``claude-code``, ``cursor``, ...), a small bounded set.
+  Distinct-user and per-client session counts are derived in-process from rolling
+  TTL sets and exposed only as aggregate gauges.
+* **Stateless sessions.** The hosted transport is stateless — every HTTP request
+  is its own short-lived MCP session. "Session" metrics therefore describe user
+  activity windows: a session starts when a (client, user) pair is first seen and
+  ends after ``ACTIVE_WINDOW_SECONDS`` without traffic ("idle" disconnect).
 
 Configuration (env):
 
@@ -31,28 +43,65 @@ Configuration (env):
 from __future__ import annotations
 
 import os
+import re
 import socket
 import sys
 import threading
 import time
+from contextvars import ContextVar
 from typing import Any, Iterable
 
 from .constants import ACTIVE_WINDOW_SECONDS
 
 _enabled = False
 _lock = threading.Lock()
+_transport = "http"
 
 # Metric instruments, populated by init_telemetry when enabled.
 _instruments: dict[str, Any] = {}
 
-# Rolling TTL sets for the active-user/active-client observable gauges. Keys expire
-# after ACTIVE_WINDOW_SECONDS so the gauges reflect a recent window, not all time.
-_active_users: dict[str, float] = {}
-_active_clients: dict[str, float] = {}  # key: client name -> last-seen monotonic-ish ts
+# Rolling TTL stores behind the observable gauges. All expire after
+# ACTIVE_WINDOW_SECONDS so the gauges reflect a recent window, not all time.
+_active_users: dict[str, float] = {}  # subject -> expiry
+# (client, subject) -> [first_seen, expiry]; pruning records session duration
+# and an "idle" disconnect.
+_active_sessions: dict[tuple[str, str], list[float]] = {}
+# (protocol version, client, subject) -> expiry
+_active_versions: dict[tuple[str, str, str], float] = {}
+# subject -> expiry; users that recently hit an Appwrite rate limit (429)
+_rate_limited: dict[str, float] = {}
 _active_lock = threading.Lock()
 
-# Dedupe initialize events: one per MCP session object.
+# Dedupe connection events: one per MCP session object.
 _seen_sessions: set[int] = set()
+
+# Identity of the request currently being served, set once per request by the
+# MCP handlers and read by every record helper that labels by client.
+_request_client: ContextVar[str] = ContextVar("appwrite_mcp_client", default="unknown")
+_request_subject: ContextVar[str | None] = ContextVar(
+    "appwrite_mcp_subject", default=None
+)
+
+# CPU gauge state: previous (wall clock, process cpu time) sample.
+_cpu_sample: list[float] = []
+
+_BYTE_BUCKETS: list[float] = [
+    64,
+    256,
+    1024,
+    4096,
+    16384,
+    65536,
+    262144,
+    1048576,
+    4194304,
+    16777216,
+]
+_TOKEN_BUCKETS: list[float] = [16, 64, 256, 1024, 4096, 16384, 65536, 262144]
+# Rough but stable chars-per-token heuristic for JSON/English payloads.
+_CHARS_PER_TOKEN = 4
+
+_TOOL_NAME_SAFE = re.compile(r"[^A-Za-z0-9_.:-]")
 
 
 def _log(message: str) -> None:
@@ -127,38 +176,185 @@ def _instance_id() -> str:
     return os.getenv("HOSTNAME") or socket.gethostname() or "unknown"
 
 
+def _histogram(
+    meter: Any,
+    name: str,
+    *,
+    unit: str,
+    description: str,
+    boundaries: list[float] | None = None,
+) -> Any:
+    if boundaries is not None:
+        try:
+            return meter.create_histogram(
+                name,
+                unit=unit,
+                description=description,
+                explicit_bucket_boundaries_advisory=boundaries,
+            )
+        except TypeError:  # pragma: no cover - older SDK without advisory support
+            pass
+    return meter.create_histogram(name, unit=unit, description=description)
+
+
 def _build_instruments(meter: Any, transport: str, version: str) -> None:
-    _instruments["initializations"] = meter.create_counter(
-        "mcp.initializations",
-        unit="{init}",
-        description="MCP initialize handshakes (connections / logins).",
+    global _transport
+    _transport = "streamable-http" if transport == "http" else transport
+
+    # --- Transport & sessions ------------------------------------------------
+    _instruments["connection"] = meter.create_counter(
+        "mcp.connection",
+        unit="{connection}",
+        description="New MCP sessions (initialize handshakes) by transport.",
     )
-    _instruments["requests"] = meter.create_counter(
-        "mcp.requests",
-        unit="{request}",
-        description="Instrumented MCP JSON-RPC handler calls.",
+    _instruments["handshake"] = meter.create_counter(
+        "mcp.handshake",
+        unit="{handshake}",
+        description="MCP handshake outcomes: initialized sessions vs rejected tokens.",
     )
-    _instruments["request_duration"] = meter.create_histogram(
-        "mcp.request.duration",
+    _instruments["session_duration"] = _histogram(
+        meter,
+        "mcp.session.duration",
         unit="s",
-        description="MCP request handler duration.",
+        description="User activity-session length (first to last request, idle-bounded).",
     )
+    _instruments["session_disconnects"] = meter.create_counter(
+        "mcp.session.disconnects",
+        unit="{disconnect}",
+        description="Activity-session ends by reason (stateless transport: idle expiry).",
+    )
+
+    # --- Protocol & messages -------------------------------------------------
+    _instruments["messages_received"] = meter.create_counter(
+        "mcp.messages.received",
+        unit="{message}",
+        description="Instrumented MCP JSON-RPC handler calls by message type.",
+    )
+    _instruments["message_latency"] = _histogram(
+        meter,
+        "mcp.message.latency",
+        unit="s",
+        description="MCP message handler duration.",
+    )
+    _instruments["jsonrpc_errors"] = meter.create_counter(
+        "mcp.jsonrpc.errors",
+        unit="{error}",
+        description="MCP handler failures by JSON-RPC error code.",
+    )
+    _instruments["message_size"] = _histogram(
+        meter,
+        "mcp.message.size",
+        unit="By",
+        description="Approximate MCP payload size by direction.",
+        boundaries=_BYTE_BUCKETS,
+    )
+
+    # --- Tool execution -------------------------------------------------------
     _instruments["tool_calls"] = meter.create_counter(
         "mcp.tool.calls",
         unit="{call}",
         description="Public operator tool invocations.",
     )
-    _instruments["tool_duration"] = meter.create_histogram(
+    _instruments["tool_duration"] = _histogram(
+        meter,
         "mcp.tool.duration",
         unit="s",
         description="Public operator tool duration.",
     )
+    _instruments["tool_errors"] = meter.create_counter(
+        "mcp.tool.errors",
+        unit="{error}",
+        description="Failed public operator tool invocations by error type.",
+    )
+    _instruments["tool_inflight"] = meter.create_up_down_counter(
+        "mcp.tool.inflight",
+        unit="{call}",
+        description="Tool calls currently executing, per tool.",
+    )
+    _instruments["tool_inflight_total"] = meter.create_up_down_counter(
+        "mcp.tool.inflight.total",
+        unit="{call}",
+        description="Tool calls currently executing across all tools.",
+    )
+    _instruments["tool_result_size"] = _histogram(
+        meter,
+        "mcp.tool.result.size",
+        unit="By",
+        description="Tool result payload size.",
+        boundaries=_BYTE_BUCKETS,
+    )
+    _instruments["tool_hallucination"] = meter.create_counter(
+        "mcp.tool.hallucination",
+        unit="{call}",
+        description="Calls to tools that do not exist (hallucinated tool names).",
+    )
+
+    # --- Agentic & token metrics ----------------------------------------------
+    _instruments["token_usage"] = meter.create_counter(
+        "mcp.token.usage",
+        unit="{token}",
+        description="Estimated tokens moved through tools (chars/4 heuristic).",
+    )
+    _instruments["token_usage_per_call"] = _histogram(
+        meter,
+        "mcp.token.usage.per.call",
+        unit="{token}",
+        description="Estimated tokens per tool call (input + output).",
+        boundaries=_TOKEN_BUCKETS,
+    )
+
+    # --- Rate limiting ---------------------------------------------------------
+    _instruments["rate_limit"] = meter.create_counter(
+        "mcp.rate.limit",
+        unit="{event}",
+        description="Appwrite API rate-limit (HTTP 429) responses surfaced to tools.",
+    )
+
+    # --- Resource access --------------------------------------------------------
+    _instruments["resource_accessed"] = meter.create_counter(
+        "mcp.resource.accessed",
+        unit="{read}",
+        description="resources/read calls by resource type.",
+    )
+    _instruments["resource_errors"] = meter.create_counter(
+        "mcp.resource.errors",
+        unit="{error}",
+        description="Failed resources/read calls by resource type.",
+    )
+    _instruments["resource_size"] = _histogram(
+        meter,
+        "mcp.resource.size",
+        unit="By",
+        description="Resource payload size served by resources/read.",
+        boundaries=_BYTE_BUCKETS,
+    )
+    _instruments["resource_anomaly"] = meter.create_counter(
+        "mcp.resource.access.anomaly",
+        unit="{event}",
+        description="Suspicious resource reads (unknown or expired URIs).",
+    )
+
+    # --- HTTP layer ----------------------------------------------------------------
+    _instruments["http_requests"] = meter.create_counter(
+        "http.requests",
+        unit="{request}",
+        description="HTTP requests served by the hosted transport, by handler.",
+    )
+    _instruments["http_request_duration"] = _histogram(
+        meter,
+        "http.request.duration",
+        unit="s",
+        description="HTTP request duration by handler.",
+    )
+
+    # --- Appwrite-specific operator metrics (not on the reference dashboard) -----
     _instruments["appwrite_calls"] = meter.create_counter(
         "mcp.appwrite.calls",
         unit="{call}",
         description="Hidden Appwrite catalog tool executions.",
     )
-    _instruments["appwrite_call_duration"] = meter.create_histogram(
+    _instruments["appwrite_call_duration"] = _histogram(
+        meter,
         "mcp.appwrite.call.duration",
         unit="s",
         description="Underlying Appwrite REST call duration.",
@@ -178,7 +374,8 @@ def _build_instruments(meter: Any, transport: str, version: str) -> None:
         unit="{query}",
         description="appwrite_search_tools catalog searches.",
     )
-    _instruments["search_tools_results"] = meter.create_histogram(
+    _instruments["search_tools_results"] = _histogram(
+        meter,
         "mcp.search_tools.results",
         unit="{match}",
         description="Match count returned by appwrite_search_tools.",
@@ -188,7 +385,8 @@ def _build_instruments(meter: Any, transport: str, version: str) -> None:
         unit="{query}",
         description="appwrite_search_docs documentation searches.",
     )
-    _instruments["search_docs_embedding_duration"] = meter.create_histogram(
+    _instruments["search_docs_embedding_duration"] = _histogram(
+        meter,
         "mcp.search_docs.embedding.duration",
         unit="s",
         description="Query embedding duration for docs search.",
@@ -203,44 +401,64 @@ def _build_instruments(meter: Any, transport: str, version: str) -> None:
         unit="{validation}",
         description="Bearer-token validation outcomes.",
     )
-    _instruments["auth_duration"] = meter.create_histogram(
+    _instruments["auth_duration"] = _histogram(
+        meter,
         "mcp.auth.duration",
         unit="s",
         description="Bearer-token verification duration.",
-    )
-    _instruments["resources_reads"] = meter.create_counter(
-        "mcp.resources.reads",
-        unit="{read}",
-        description="resources/read calls.",
     )
     _instruments["uploads"] = meter.create_counter(
         "mcp.uploads",
         unit="{upload}",
         description="File upload attempts.",
     )
-    _instruments["upload_bytes"] = meter.create_histogram(
+    _instruments["upload_bytes"] = _histogram(
+        meter,
         "mcp.upload.bytes",
         unit="By",
         description="Uploaded file size.",
+        boundaries=_BYTE_BUCKETS,
     )
     _instruments["upload_errors"] = meter.create_counter(
         "mcp.upload.errors",
         unit="{error}",
         description="File upload failures.",
     )
-    # Observable gauges: distinct active users/clients over a rolling window, and a
-    # build-info gauge (always 1, carries version/transport labels).
+
+    # --- Observable gauges ------------------------------------------------------
     meter.create_observable_gauge(
-        "mcp.users.active",
-        callbacks=[_observe_active_users],
-        unit="{user}",
-        description="Distinct authenticated users seen in the last 5 minutes.",
+        "mcp.active_sessions",
+        callbacks=[_observe_active_sessions],
+        unit="{session}",
+        description="Distinct authenticated users active in the last 5 minutes.",
     )
     meter.create_observable_gauge(
-        "mcp.clients.active",
-        callbacks=[_observe_active_clients],
-        unit="{client}",
-        description="Distinct connected agents seen in the last 5 minutes.",
+        "mcp.active_sessions.by_client",
+        callbacks=[_observe_active_sessions_by_client],
+        unit="{session}",
+        description="Active (client, user) sessions in the last 5 minutes, per client.",
+    )
+    meter.create_observable_gauge(
+        "mcp.protocol.version.count",
+        callbacks=[_observe_protocol_versions],
+        unit="{session}",
+        description="Active sessions by negotiated MCP protocol version and client.",
+    )
+    meter.create_observable_gauge(
+        "mcp.rate.limit.active",
+        callbacks=[_observe_rate_limited],
+        unit="{user}",
+        description="Distinct users rate-limited by Appwrite in the last 5 minutes.",
+    )
+    meter.create_observable_gauge(
+        "mcp.cpu.usage.percent",
+        callbacks=[_observe_cpu],
+        description="Process CPU usage since the previous observation, percent.",
+    )
+    meter.create_observable_gauge(
+        "mcp.memory.usage.mb",
+        callbacks=[_observe_memory],
+        description="Process resident memory, megabytes.",
     )
 
     def _observe_info(_options: Any):
@@ -256,58 +474,159 @@ def _build_instruments(meter: Any, transport: str, version: str) -> None:
     )
 
 
-# --- Active-set bookkeeping -------------------------------------------------
+# --- Request identity ---------------------------------------------------------
 
 
-def _prune(store: dict[str, float], now: float) -> None:
-    expired = [key for key, ts in store.items() if ts < now]
+def set_request_identity(
+    *,
+    client_name: str | None,
+    subject: str | None,
+    protocol_version: str | None = None,
+) -> None:
+    """Bind the current request's client/user identity to the calling context and
+    refresh the rolling activity stores. Contextvars propagate into the worker
+    threads that execute tools, so record helpers can label by client."""
+    client = client_name or "unknown"
+    _request_client.set(client)
+    _request_subject.set(subject)
+    if not _enabled:
+        # The rolling stores are only pruned by the gauge callbacks, which never
+        # run while disabled — do not let them grow.
+        return
+    now = time.monotonic()
+    expiry = now + ACTIVE_WINDOW_SECONDS
+    with _active_lock:
+        if subject:
+            _active_users[subject] = expiry
+            session = _active_sessions.get((client, subject))
+            if session is None:
+                _active_sessions[(client, subject)] = [now, expiry]
+            else:
+                session[1] = expiry
+            if protocol_version:
+                _active_versions[(protocol_version, client, subject)] = expiry
+
+
+def current_client_id() -> str:
+    return _request_client.get()
+
+
+# --- Active-set bookkeeping -----------------------------------------------------
+
+
+def _prune(store: dict, now: float) -> list:
+    expired = [key for key, value in store.items() if _expiry(value) < now]
     for key in expired:
         del store[key]
+    return expired
 
 
-def _observe_active_users(_options: Any) -> Iterable[Any]:
+def _expiry(value: Any) -> float:
+    return value[1] if isinstance(value, list) else value
+
+
+def _observe_active_sessions(_options: Any) -> Iterable[Any]:
     from opentelemetry.metrics import Observation
 
     now = time.monotonic()
     with _active_lock:
         _prune(_active_users, now)
+        _prune(_active_versions, now)
         count = len(_active_users)
     return [Observation(count)]
 
 
-def _observe_active_clients(_options: Any) -> Iterable[Any]:
+def _observe_active_sessions_by_client(_options: Any) -> Iterable[Any]:
     from opentelemetry.metrics import Observation
 
     now = time.monotonic()
     counts: dict[str, int] = {}
+    ended: list[tuple[tuple[str, str], list[float]]] = []
     with _active_lock:
-        _prune(_active_clients, now)
-        for compound_key in _active_clients:
-            client_name = compound_key.split("\x00", 1)[0]
-            counts[client_name] = counts.get(client_name, 0) + 1
-    return [Observation(n, {"client.name": name}) for name, n in counts.items()]
+        expired = [key for key, session in _active_sessions.items() if session[1] < now]
+        for key in expired:
+            ended.append((key, _active_sessions.pop(key)))
+        for client, _subject in _active_sessions:
+            counts[client] = counts.get(client, 0) + 1
+    # Expired sessions were idle for the full window; the session itself lasted
+    # from first sight to the start of that idle period.
+    for (client, _subject), (first_seen, expiry) in ended:
+        duration = max(0.0, (expiry - ACTIVE_WINDOW_SECONDS) - first_seen)
+        _safe_record("session_duration", duration, {})
+        _safe_add("session_disconnects", 1, {"client_id": client, "reason": "idle"})
+    return [Observation(n, {"client_id": name}) for name, n in counts.items()]
 
 
-def _touch_user(subject: str | None) -> None:
-    if not subject:
-        return
-    expiry = time.monotonic() + ACTIVE_WINDOW_SECONDS
+def _observe_protocol_versions(_options: Any) -> Iterable[Any]:
+    from opentelemetry.metrics import Observation
+
+    now = time.monotonic()
+    counts: dict[tuple[str, str], int] = {}
     with _active_lock:
-        _active_users[subject] = expiry
+        _prune(_active_versions, now)
+        for version, client, _subject in _active_versions:
+            counts[(version, client)] = counts.get((version, client), 0) + 1
+    return [
+        Observation(n, {"version": version, "client_id": client})
+        for (version, client), n in counts.items()
+    ]
 
 
-def _touch_client(client_name: str | None, subject: str | None) -> None:
-    # Keyed by (client_name, subject) so the per-client gauge counts distinct users
-    # of each agent. subject stays in-process only.
-    if not client_name:
-        return
-    key = f"{client_name}\x00{subject or ''}"
-    expiry = time.monotonic() + ACTIVE_WINDOW_SECONDS
+def _observe_rate_limited(_options: Any) -> Iterable[Any]:
+    from opentelemetry.metrics import Observation
+
+    now = time.monotonic()
     with _active_lock:
-        _active_clients[key] = expiry
+        _prune(_rate_limited, now)
+        count = len(_rate_limited)
+    return [Observation(count)]
 
 
-# --- Record helpers (all exception-safe, no-op when disabled) ---------------
+def _observe_cpu(_options: Any) -> Iterable[Any]:
+    from opentelemetry.metrics import Observation
+
+    times = os.times()
+    wall = time.monotonic()
+    cpu = times.user + times.system
+    if not _cpu_sample:
+        _cpu_sample.extend([wall, cpu])
+        return []
+    prev_wall, prev_cpu = _cpu_sample[0], _cpu_sample[1]
+    _cpu_sample[0], _cpu_sample[1] = wall, cpu
+    elapsed = wall - prev_wall
+    if elapsed <= 0:
+        return []
+    return [Observation(max(0.0, (cpu - prev_cpu) / elapsed * 100.0))]
+
+
+def _observe_memory(_options: Any) -> Iterable[Any]:
+    from opentelemetry.metrics import Observation
+
+    rss = _resident_bytes()
+    if rss is None:
+        return []
+    return [Observation(rss / (1024 * 1024))]
+
+
+def _resident_bytes() -> float | None:
+    try:
+        with open("/proc/self/status", encoding="ascii", errors="ignore") as status:
+            for line in status:
+                if line.startswith("VmRSS:"):
+                    return float(line.split()[1]) * 1024
+    except OSError:
+        pass
+    try:
+        import resource
+
+        peak = float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+        # ru_maxrss is bytes on macOS, kilobytes on Linux.
+        return peak if sys.platform == "darwin" else peak * 1024
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+# --- Record helpers (all exception-safe, no-op when disabled) --------------------
 
 
 def _safe_add(name: str, value: int, attributes: dict[str, Any]) -> None:
@@ -332,30 +651,36 @@ def _clean(attributes: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in attributes.items() if v is not None}
 
 
-def record_request(method: str, outcome: str, duration_s: float) -> None:
-    _safe_add("requests", 1, {"mcp.method": method, "outcome": outcome})
-    _safe_record(
-        "request_duration", duration_s, {"mcp.method": method, "outcome": outcome}
-    )
+def _estimate_tokens(size_chars: int) -> int:
+    return max(1, size_chars // _CHARS_PER_TOKEN) if size_chars > 0 else 0
 
 
-def record_initialize(
+def _sanitize_tool_name(name: Any) -> str:
+    text = str(name) if name is not None else ""
+    text = _TOOL_NAME_SAFE.sub("_", text)[:64]
+    return text or "invalid"
+
+
+# --- Transport & sessions ---------------------------------------------------------
+
+
+def record_connection(
     *,
     session_id: int,
     client_name: str | None,
     client_version: str | None,
     protocol_version: str | None,
-    oauth_client_id: str | None,
     subject: str | None,
 ) -> None:
+    """Count a new MCP session (connection + successful handshake), deduped per
+    session object, and refresh the request-identity stores."""
+    set_request_identity(
+        client_name=client_name,
+        subject=subject,
+        protocol_version=protocol_version,
+    )
     if not _enabled:
         return
-    # Refresh active-user/client tracking on every request (not just new sessions)
-    # so the rolling-window gauges reflect recency. Entries are expired by the gauge
-    # callbacks during the SDK's collection cycle — which only runs while enabled, so
-    # these sets must not be touched when telemetry is disabled (they'd never prune).
-    _touch_user(subject)
-    _touch_client(client_name, subject)
     with _active_lock:
         if session_id in _seen_sessions:
             return
@@ -364,23 +689,179 @@ def record_initialize(
         if len(_seen_sessions) > 100_000:
             _seen_sessions.clear()
             _seen_sessions.add(session_id)
+    client = client_name or "unknown"
     _safe_add(
-        "initializations",
+        "connection",
         1,
         {
-            "client.name": client_name or "unknown",
-            "client.version": client_version,
-            "mcp.protocol.version": protocol_version,
-            "oauth.client_id": oauth_client_id,
+            "transport": _transport,
+            "client_id": client,
+            "client_version": client_version,
+        },
+    )
+    _safe_add("handshake", 1, {"status": "success", "client_id": client})
+
+
+def record_handshake_failure(reason: str | None = None) -> None:
+    """A presented bearer token was rejected — the session never initialized."""
+    _safe_add(
+        "handshake",
+        1,
+        {"status": "failure", "client_id": current_client_id(), "reason": reason},
+    )
+
+
+# --- Protocol & messages ------------------------------------------------------------
+
+
+def record_message(
+    method: str,
+    outcome: str,
+    duration_s: float,
+    *,
+    error_code: int | None = None,
+    error_message: str | None = None,
+) -> None:
+    _safe_add(
+        "messages_received",
+        1,
+        {"msg_type": method, "client_id": current_client_id(), "outcome": outcome},
+    )
+    _safe_record("message_latency", duration_s, {"msg_type": method})
+    if outcome == "error":
+        _safe_add(
+            "jsonrpc_errors",
+            1,
+            {
+                "error_code": str(error_code if error_code is not None else -32603),
+                "error_message": error_message or "InternalError",
+            },
+        )
+
+
+def record_message_size(direction: str, size_bytes: int) -> None:
+    _safe_record("message_size", size_bytes, {"direction": direction})
+
+
+# --- Tool execution --------------------------------------------------------------------
+
+
+def tool_call_started(tool_name: str) -> None:
+    _safe_add("tool_inflight", 1, {"tool_name": tool_name})
+    _safe_add("tool_inflight_total", 1, {})
+
+
+def record_tool_call(
+    tool_name: str,
+    status: str,
+    duration_s: float,
+    *,
+    error_type: str | None = None,
+    input_chars: int | None = None,
+    output_chars: int | None = None,
+) -> None:
+    """Finish a tool call started with ``tool_call_started``."""
+    client = current_client_id()
+    _safe_add("tool_inflight", -1, {"tool_name": tool_name})
+    _safe_add("tool_inflight_total", -1, {})
+    _safe_add(
+        "tool_calls",
+        1,
+        {"tool_name": tool_name, "client_id": client, "status": status},
+    )
+    _safe_record("tool_duration", duration_s, {"tool_name": tool_name})
+    if status == "error":
+        _safe_add(
+            "tool_errors",
+            1,
+            {"tool_name": tool_name, "error_type": error_type or "unknown"},
+        )
+
+    input_tokens = _estimate_tokens(input_chars or 0)
+    output_tokens = _estimate_tokens(output_chars or 0)
+    if input_chars:
+        record_message_size("received", input_chars)
+        _safe_add(
+            "token_usage", input_tokens, {"tool_name": tool_name, "direction": "input"}
+        )
+    if output_chars:
+        record_message_size("sent", output_chars)
+        _safe_record("tool_result_size", output_chars, {"tool_name": tool_name})
+        _safe_add(
+            "token_usage",
+            output_tokens,
+            {"tool_name": tool_name, "direction": "output"},
+        )
+    if input_chars or output_chars:
+        _safe_record(
+            "token_usage_per_call",
+            input_tokens + output_tokens,
+            {"tool_name": tool_name},
+        )
+
+
+def record_hallucination(attempted_tool: Any) -> None:
+    _safe_add(
+        "tool_hallucination",
+        1,
+        {
+            "attempted_tool": _sanitize_tool_name(attempted_tool),
+            "client_id": current_client_id(),
         },
     )
 
 
-def record_tool_call(tool_name: str, outcome: str, duration_s: float) -> None:
-    _safe_add("tool_calls", 1, {"tool.name": tool_name, "outcome": outcome})
-    _safe_record(
-        "tool_duration", duration_s, {"tool.name": tool_name, "outcome": outcome}
+def record_rate_limit(tool_name: str) -> None:
+    _safe_add(
+        "rate_limit",
+        1,
+        {"tool_name": tool_name, "client_id": current_client_id()},
     )
+    subject = _request_subject.get()
+    if not _enabled or not subject:
+        return
+    with _active_lock:
+        _rate_limited[subject] = time.monotonic() + ACTIVE_WINDOW_SECONDS
+
+
+# --- Resource access -----------------------------------------------------------------
+
+
+def record_resource_access(
+    resource: str,
+    *,
+    outcome: str = "success",
+    size_bytes: int | None = None,
+    anomaly: str | None = None,
+) -> None:
+    _safe_add(
+        "resource_accessed",
+        1,
+        {"resource": resource, "client_id": current_client_id()},
+    )
+    if outcome == "error":
+        _safe_add("resource_errors", 1, {"resource": resource})
+    if size_bytes is not None:
+        _safe_record("resource_size", size_bytes, {"resource": resource})
+    if anomaly:
+        _safe_add("resource_anomaly", 1, {"anomaly_type": anomaly})
+
+
+# --- HTTP layer -------------------------------------------------------------------------
+
+
+def record_http_request(
+    handler: str, method: str, status_code: int, duration_s: float
+) -> None:
+    _safe_add(
+        "http_requests",
+        1,
+        {"handler": handler, "method": method, "code": str(status_code)},
+    )
+    _safe_record("http_request_duration", duration_s, {"handler": handler})
+
+
+# --- Appwrite-specific helpers (unchanged surface) -----------------------------------
 
 
 def record_appwrite_call(
@@ -467,10 +948,6 @@ def record_auth(
         _safe_add("auth_validations", 1, {"outcome": outcome, "reason": reason})
     if duration_s is not None:
         _safe_record("auth_duration", duration_s, {"outcome": outcome})
-
-
-def record_resource_read(resource_type: str) -> None:
-    _safe_add("resources_reads", 1, {"resource.type": resource_type})
 
 
 def record_upload(*, source: str, outcome: str, size_bytes: int | None = None) -> None:

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 
 import mcp.types as types
@@ -5,6 +6,7 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 from mcp_server_appwrite import telemetry
+from mcp_server_appwrite.constants import ACTIVE_WINDOW_SECONDS
 from mcp_server_appwrite.operator import Operator
 from mcp_server_appwrite.tool_manager import ToolManager
 
@@ -31,15 +33,21 @@ class TelemetryHarness(unittest.TestCase):
         provider = MeterProvider(metric_readers=[self.reader])
         meter = provider.get_meter("test")
         telemetry._instruments.clear()
+        self._clear_stores()
         telemetry._build_instruments(meter, "http", "test")
         telemetry._enabled = True
 
     def tearDown(self) -> None:
         telemetry._enabled = False
         telemetry._instruments.clear()
+        self._clear_stores()
+
+    def _clear_stores(self) -> None:
         with telemetry._active_lock:
             telemetry._active_users.clear()
-            telemetry._active_clients.clear()
+            telemetry._active_sessions.clear()
+            telemetry._active_versions.clear()
+            telemetry._rate_limited.clear()
             telemetry._seen_sessions.clear()
 
     def points(self, metric_name: str) -> list:
@@ -55,6 +63,15 @@ class TelemetryHarness(unittest.TestCase):
 
     def assertAttr(self, point, key, value):
         self.assertEqual(point.attributes.get(key), value)
+
+    def connect(self, session_id=1, client="claude-code", subject="user-a"):
+        telemetry.record_connection(
+            session_id=session_id,
+            client_name=client,
+            client_version="1.0",
+            protocol_version="2025-06-18",
+            subject=subject,
+        )
 
 
 class RecordHelperTests(TelemetryHarness):
@@ -102,41 +119,191 @@ class RecordHelperTests(TelemetryHarness):
         self.assertEqual(validations[0].value, 1)
         self.assertAttr(validations[0], "reason", "signature")
 
-    def test_active_users_gauge_counts_distinct_subjects(self):
-        telemetry.record_initialize(
-            session_id=1,
-            client_name="claude",
-            client_version="1.0",
-            protocol_version="2025-06-18",
-            oauth_client_id="app-1",
-            subject="user-a",
-        )
-        telemetry.record_initialize(
-            session_id=2,
-            client_name="claude",
-            client_version="1.0",
-            protocol_version="2025-06-18",
-            oauth_client_id="app-1",
-            subject="user-b",
-        )
-        users = self.points("mcp.users.active")
-        self.assertEqual(users[0].value, 2)
-        inits = self.points("mcp.initializations")
-        self.assertEqual(sum(p.value for p in inits), 2)
-        self.assertAttr(inits[0], "client.name", "claude")
 
-    def test_initialize_deduped_per_session(self):
+class SessionTests(TelemetryHarness):
+    def test_active_sessions_counts_distinct_subjects(self):
+        self.connect(session_id=1, subject="user-a")
+        self.connect(session_id=2, subject="user-b")
+        sessions = self.points("mcp.active_sessions")
+        self.assertEqual(sessions[0].value, 2)
+        connections = self.points("mcp.connection")
+        self.assertEqual(sum(p.value for p in connections), 2)
+        self.assertAttr(connections[0], "client_id", "claude-code")
+        self.assertAttr(connections[0], "transport", "streamable-http")
+        handshakes = self.points("mcp.handshake")
+        self.assertEqual(sum(p.value for p in handshakes), 2)
+        self.assertAttr(handshakes[0], "status", "success")
+
+    def test_active_sessions_by_client_and_protocol_version(self):
+        self.connect(session_id=1, client="claude-code", subject="user-a")
+        self.connect(session_id=2, client="cursor", subject="user-b")
+        by_client = self.points("mcp.active_sessions.by_client")
+        counts = {p.attributes["client_id"]: p.value for p in by_client}
+        self.assertEqual(counts, {"claude-code": 1, "cursor": 1})
+        versions = self.points("mcp.protocol.version.count")
+        self.assertEqual(sum(p.value for p in versions), 2)
+        self.assertAttr(versions[0], "version", "2025-06-18")
+
+    def test_connection_deduped_per_session(self):
         for _ in range(3):
-            telemetry.record_initialize(
-                session_id=42,
-                client_name="cursor",
-                client_version="2.0",
-                protocol_version="2025-06-18",
-                oauth_client_id="app-2",
-                subject="user-c",
-            )
-        inits = self.points("mcp.initializations")
-        self.assertEqual(sum(p.value for p in inits), 1)
+            self.connect(session_id=42, client="cursor", subject="user-c")
+        connections = self.points("mcp.connection")
+        self.assertEqual(sum(p.value for p in connections), 1)
+
+    def test_expired_session_records_duration_and_idle_disconnect(self):
+        self.connect(session_id=1, client="cursor", subject="user-a")
+        with telemetry._active_lock:
+            first_seen, _expiry = telemetry._active_sessions[("cursor", "user-a")]
+            telemetry._active_sessions[("cursor", "user-a")] = [
+                first_seen - 60,
+                time.monotonic() - 1,
+            ]
+        by_client = self.points("mcp.active_sessions.by_client")
+        self.assertEqual(by_client, [])
+        durations = self.points("mcp.session.duration")
+        self.assertEqual(durations[0].count, 1)
+        disconnects = self.points("mcp.session.disconnects")
+        self.assertAttr(disconnects[0], "reason", "idle")
+        self.assertAttr(disconnects[0], "client_id", "cursor")
+
+    def test_handshake_failure(self):
+        telemetry.record_handshake_failure(reason="invalid_token")
+        handshakes = self.points("mcp.handshake")
+        self.assertEqual(len(handshakes), 1)
+        self.assertAttr(handshakes[0], "status", "failure")
+
+
+class MessageTests(TelemetryHarness):
+    def test_message_success(self):
+        self.connect()
+        telemetry.record_message("tools/call", "success", 0.01)
+        messages = self.points("mcp.messages.received")
+        self.assertEqual(len(messages), 1)
+        self.assertAttr(messages[0], "msg_type", "tools/call")
+        self.assertAttr(messages[0], "client_id", "claude-code")
+        latency = self.points("mcp.message.latency")
+        self.assertEqual(latency[0].count, 1)
+        self.assertEqual(self.points("mcp.jsonrpc.errors"), [])
+
+    def test_message_error_emits_jsonrpc_error(self):
+        telemetry.record_message(
+            "tools/call",
+            "error",
+            0.01,
+            error_code=-32602,
+            error_message="ValueError",
+        )
+        errors = self.points("mcp.jsonrpc.errors")
+        self.assertEqual(len(errors), 1)
+        self.assertAttr(errors[0], "error_code", "-32602")
+        self.assertAttr(errors[0], "error_message", "ValueError")
+
+    def test_message_size_by_direction(self):
+        telemetry.record_message_size("received", 128)
+        telemetry.record_message_size("sent", 4096)
+        sizes = self.points("mcp.message.size")
+        directions = {p.attributes["direction"]: p.sum for p in sizes}
+        self.assertEqual(directions, {"received": 128, "sent": 4096})
+
+
+class ToolExecutionTests(TelemetryHarness):
+    def test_tool_call_success_with_sizes_and_tokens(self):
+        self.connect()
+        telemetry.tool_call_started("appwrite_call_tool")
+        telemetry.record_tool_call(
+            "appwrite_call_tool",
+            "success",
+            0.2,
+            input_chars=400,
+            output_chars=2000,
+        )
+        calls = self.points("mcp.tool.calls")
+        self.assertEqual(len(calls), 1)
+        self.assertAttr(calls[0], "tool_name", "appwrite_call_tool")
+        self.assertAttr(calls[0], "client_id", "claude-code")
+        self.assertAttr(calls[0], "status", "success")
+        inflight = self.points("mcp.tool.inflight")
+        self.assertEqual(inflight[0].value, 0)
+        inflight_total = self.points("mcp.tool.inflight.total")
+        self.assertEqual(inflight_total[0].value, 0)
+        result_size = self.points("mcp.tool.result.size")
+        self.assertEqual(result_size[0].sum, 2000)
+        tokens = {
+            p.attributes["direction"]: p.value for p in self.points("mcp.token.usage")
+        }
+        self.assertEqual(tokens, {"input": 100, "output": 500})
+        per_call = self.points("mcp.token.usage.per.call")
+        self.assertEqual(per_call[0].sum, 600)
+        self.assertEqual(self.points("mcp.tool.errors"), [])
+
+    def test_tool_call_error_emits_error_type(self):
+        telemetry.tool_call_started("appwrite_search_tools")
+        telemetry.record_tool_call(
+            "appwrite_search_tools", "error", 0.05, error_type="ValueError"
+        )
+        errors = self.points("mcp.tool.errors")
+        self.assertEqual(len(errors), 1)
+        self.assertAttr(errors[0], "tool_name", "appwrite_search_tools")
+        self.assertAttr(errors[0], "error_type", "ValueError")
+
+    def test_hallucination_sanitizes_tool_name(self):
+        self.connect()
+        telemetry.record_hallucination("no such tool!{}" + "x" * 100)
+        points = self.points("mcp.tool.hallucination")
+        self.assertEqual(len(points), 1)
+        attempted = points[0].attributes["attempted_tool"]
+        self.assertLessEqual(len(attempted), 64)
+        self.assertNotIn(" ", attempted)
+        self.assertNotIn("!", attempted)
+
+    def test_rate_limit_marks_active_subject(self):
+        self.connect(subject="user-a")
+        telemetry.record_rate_limit("tables_db_create")
+        events = self.points("mcp.rate.limit")
+        self.assertAttr(events[0], "tool_name", "tables_db_create")
+        active = self.points("mcp.rate.limit.active")
+        self.assertEqual(active[0].value, 1)
+
+
+class ResourceTests(TelemetryHarness):
+    def test_resource_access_success_records_size(self):
+        self.connect()
+        telemetry.record_resource_access("result", size_bytes=2048)
+        accessed = self.points("mcp.resource.accessed")
+        self.assertAttr(accessed[0], "resource", "result")
+        sizes = self.points("mcp.resource.size")
+        self.assertEqual(sizes[0].sum, 2048)
+        self.assertEqual(self.points("mcp.resource.errors"), [])
+
+    def test_resource_access_error_records_anomaly(self):
+        telemetry.record_resource_access(
+            "result", outcome="error", anomaly="unknown_resource"
+        )
+        errors = self.points("mcp.resource.errors")
+        self.assertEqual(len(errors), 1)
+        anomalies = self.points("mcp.resource.access.anomaly")
+        self.assertAttr(anomalies[0], "anomaly_type", "unknown_resource")
+
+
+class HttpTests(TelemetryHarness):
+    def test_http_request(self):
+        telemetry.record_http_request("/mcp", "POST", 200, 0.02)
+        requests = self.points("http.requests")
+        self.assertAttr(requests[0], "handler", "/mcp")
+        self.assertAttr(requests[0], "method", "POST")
+        self.assertAttr(requests[0], "code", "200")
+        durations = self.points("http.request.duration")
+        self.assertEqual(durations[0].count, 1)
+
+    def test_system_gauges_registered(self):
+        # CPU needs two observations for a delta; memory should report on the first.
+        self.reader.get_metrics_data()
+        cpu = self.points("mcp.cpu.usage.percent")
+        self.assertEqual(len(cpu), 1)
+        self.assertGreaterEqual(cpu[0].value, 0)
+        memory = self.points("mcp.memory.usage.mb")
+        self.assertEqual(len(memory), 1)
+        self.assertGreater(memory[0].value, 0)
 
 
 class OperatorTelemetryTests(TelemetryHarness):
@@ -199,11 +366,21 @@ class OperatorTelemetryTests(TelemetryHarness):
         calls = self.points("mcp.tool.calls")
         self.assertTrue(
             any(
-                p.attributes.get("tool.name") == "appwrite_call_tool"
-                and p.attributes.get("outcome") == "success"
+                p.attributes.get("tool_name") == "appwrite_call_tool"
+                and p.attributes.get("status") == "success"
                 for p in calls
             )
         )
+
+    def test_unknown_hidden_tool_counts_hallucination(self):
+        runtime = self.make_runtime(lambda name, arguments, *_: [])
+        with self.assertRaises(ValueError):
+            runtime.execute_public_tool(
+                "appwrite_call_tool", {"tool_name": "made_up_tool"}
+            )
+        points = self.points("mcp.tool.hallucination")
+        self.assertEqual(len(points), 1)
+        self.assertAttr(points[0], "attempted_tool", "made_up_tool")
 
 
 class NoOpTests(unittest.TestCase):
@@ -216,7 +393,7 @@ class NoOpTests(unittest.TestCase):
         telemetry._build_instruments(provider.get_meter("test"), "http", "test")
         telemetry._enabled = False
         try:
-            telemetry.record_request("tools/call", "success", 0.01)
+            telemetry.record_message("tools/call", "success", 0.01)
             telemetry.record_appwrite_call(
                 service="storage",
                 action="create",
@@ -233,7 +410,7 @@ class NoOpTests(unittest.TestCase):
                 for metric in sm.metrics
                 if metric.data.data_points
             }
-            self.assertNotIn("mcp.requests", recorded)
+            self.assertNotIn("mcp.messages.received", recorded)
             self.assertNotIn("mcp.appwrite.calls", recorded)
             self.assertNotIn("mcp.auth.validations", recorded)
         finally:
@@ -242,22 +419,27 @@ class NoOpTests(unittest.TestCase):
     def test_init_is_noop_for_stdio(self):
         self.assertFalse(telemetry.init_telemetry("stdio", "test"))
 
-    def test_record_initialize_does_not_grow_sets_when_disabled(self):
-        # When disabled, the active-user/client sets must not accumulate — they are
+    def test_record_connection_does_not_grow_stores_when_disabled(self):
+        # When disabled, the rolling activity stores must not accumulate — they are
         # only pruned by the gauge callbacks, which never run while disabled.
         telemetry._enabled = False
-        telemetry._active_users.clear()
-        telemetry._active_clients.clear()
-        telemetry.record_initialize(
+        with telemetry._active_lock:
+            telemetry._active_users.clear()
+            telemetry._active_sessions.clear()
+            telemetry._active_versions.clear()
+        telemetry.record_connection(
             session_id=7,
             client_name="claude",
             client_version="1.0",
             protocol_version="2025-06-18",
-            oauth_client_id="app",
             subject="user-x",
         )
         self.assertEqual(len(telemetry._active_users), 0)
-        self.assertEqual(len(telemetry._active_clients), 0)
+        self.assertEqual(len(telemetry._active_sessions), 0)
+        self.assertEqual(len(telemetry._active_versions), 0)
+
+    def test_session_window_constant_positive(self):
+        self.assertGreater(ACTIVE_WINDOW_SECONDS, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Reworks the telemetry layer so the hosted server emits the metric set queried by the ['MCP Server Observability' reference dashboard](https://grafana.com/grafana/dashboards/25252-mcp-server-observability/) (grafana.com 25252). Pairs with appwrite-labs/dashboards PR that rebuilds the `MCP` dashboard panel-for-panel from that reference.

## Metrics

| Area | Metrics (Prometheus names) |
| --- | --- |
| Tool execution | `mcp_tool_calls_total{tool_name,client_id,status}`, `mcp_tool_duration_seconds`, `mcp_tool_errors_total{error_type}`, `mcp_tool_inflight` / `mcp_tool_inflight_total`, `mcp_tool_result_size_bytes` |
| Agentic/tokens | `mcp_token_usage_total{direction}`, `mcp_token_usage_per_call` (chars/4 heuristic), `mcp_tool_hallucination_total{attempted_tool}` |
| Transport/sessions | `mcp_connection_total{transport}`, `mcp_handshake_total{status}`, `mcp_active_sessions`, `mcp_active_sessions_by_client`, `mcp_session_duration_seconds`, `mcp_session_disconnects_total` |
| Protocol | `mcp_messages_received_total{msg_type}`, `mcp_message_latency_seconds`, `mcp_jsonrpc_errors_total{error_code}`, `mcp_protocol_version_count`, `mcp_message_size_bytes{direction}` |
| Rate limiting | `mcp_rate_limit_total` (Appwrite 429s), `mcp_rate_limit_active` |
| Resources | `mcp_resource_accessed_total`, `mcp_resource_errors_total`, `mcp_resource_size_bytes`, `mcp_resource_access_anomaly_total` |
| System/HTTP | `mcp_cpu_usage_percent`, `mcp_memory_usage_mb`, `http_requests_total{handler}`, `http_request_duration_seconds` |

## Notes

- **Stateless transport**: sessions are rolling (client, user) activity windows — a session ends after 5 idle minutes (reason `idle`). Reconnection/prompt/self-correction/task-success panels on the reference dashboard have no honest server-side signal and stay empty.
- **Client identity**: `client_id` is the MCP client *name* (`claude-code`, `cursor`, ...) propagated via contextvars from the initialize handshake into tool handlers — bounded cardinality; no user ids/URIs as labels.
- Superseded metrics removed: `mcp_requests_total`/`mcp_request_duration_seconds` (→ messages), `mcp_initializations_total` (→ connection/handshake), `mcp_users_active`/`mcp_clients_active` (→ active_sessions), `mcp_resources_reads_total` (→ resource_accessed). Appwrite-specific metrics (auth, appwrite calls, search, uploads) unchanged.

## Testing

- `ruff`, `black --check`, `pyright`: clean; 150 unit tests pass (new coverage for every added helper).
- Docker build passes.
- Smoke-tested the ASGI app with telemetry enabled: verified `http_requests` by handler/status, handshake failure on bad token, and CPU/memory gauges via an in-memory reader.