### PR TITLE
Bind client identity at the HTTP layer for the stateless transport

### DIFF
--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import itertools
 import json
 import logging
+import re
 import sys
 import time
 from importlib.resources import files
@@ -36,7 +38,7 @@ from starlette.responses import (
     Response,
 )
 from starlette.routing import Route
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from . import error_monitoring, telemetry
 from .auth import (
@@ -182,6 +184,114 @@ def _has_authorization_header(scope: Scope) -> bool:
     return False
 
 
+_MAX_SNIFF_BYTES = 2 * 1024 * 1024
+_UA_PRODUCT = re.compile(r"^[A-Za-z0-9._-]{1,32}")
+_connection_counter = itertools.count(1)
+
+
+def _client_from_user_agent(user_agent: str | None) -> str | None:
+    """First product token of the User-Agent, e.g. ``claude-code/2.0`` ->
+    ``claude-code``. Only authenticated MCP clients reach this path, so the
+    value set stays small."""
+    if not user_agent:
+        return None
+    match = _UA_PRODUCT.match(user_agent.split("/", 1)[0].strip())
+    return match.group(0).lower() if match else None
+
+
+def _header(scope: Scope, name: bytes) -> str | None:
+    for key, value in scope.get("headers", []):
+        if key == name:
+            return value.decode("latin-1")
+    return None
+
+
+def _subject_from_scope(scope: Scope) -> str | None:
+    user = scope.get("user")
+    token = getattr(user, "access_token", None)
+    claims = getattr(token, "claims", None) or {}
+    return getattr(token, "subject", None) or claims.get("sub")
+
+
+def _find_initialize_params(body: bytes) -> dict | None:
+    try:
+        payload = json.loads(body)
+    except Exception:
+        return None
+    messages = payload if isinstance(payload, list) else [payload]
+    for message in messages:
+        if isinstance(message, dict) and message.get("method") == "initialize":
+            params = message.get("params")
+            return params if isinstance(params, dict) else {}
+    return None
+
+
+class MCPIdentityMiddleware:
+    """Bind client/user identity for every authenticated ``/mcp`` request.
+
+    The hosted transport is stateless: each POST is its own MCP session, so
+    ``session.client_params`` is only populated on the request that carries the
+    ``initialize`` message — which the SDK answers internally, before any of our
+    handlers run. This middleware peeks at the JSON-RPC body instead: an
+    ``initialize`` request is counted as a connection/handshake (with clientInfo),
+    and every other request binds identity from the ``mcp-protocol-version``
+    header and User-Agent so tool metrics carry a real ``client_id``."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope.get("method") != "POST":
+            await self.app(scope, receive, send)
+            return
+
+        chunks: list[Message] = []
+        body = b""
+        while True:
+            message = await receive()
+            chunks.append(message)
+            if message["type"] != "http.request":  # pragma: no cover - disconnect
+                break
+            body += message.get("body", b"")
+            if len(body) > _MAX_SNIFF_BYTES or not message.get("more_body", False):
+                break
+
+        try:
+            self._bind_identity(scope, body)
+        except Exception:  # pragma: no cover - telemetry must never break requests
+            pass
+
+        replayed = iter(chunks)
+
+        async def replay() -> Message:
+            try:
+                return next(replayed)
+            except StopIteration:
+                return await receive()
+
+        await self.app(scope, replay, send)
+
+    def _bind_identity(self, scope: Scope, body: bytes) -> None:
+        subject = _subject_from_scope(scope)
+        params = _find_initialize_params(body) if body else None
+        if params is not None:
+            client_info = params.get("clientInfo") or {}
+            telemetry.record_connection(
+                session_id=next(_connection_counter),
+                client_name=client_info.get("name")
+                or _client_from_user_agent(_header(scope, b"user-agent")),
+                client_version=client_info.get("version"),
+                protocol_version=params.get("protocolVersion"),
+                subject=subject,
+            )
+            return
+        telemetry.set_request_identity(
+            client_name=_client_from_user_agent(_header(scope, b"user-agent")),
+            subject=subject,
+            protocol_version=_header(scope, b"mcp-protocol-version"),
+        )
+
+
 _KNOWN_HANDLERS = {
     "/mcp",
     "/healthz",
@@ -265,7 +375,7 @@ def build_app() -> Starlette:
     async def handle_mcp(scope: Scope, receive: Receive, send: Send) -> None:
         await session_manager.handle_request(scope, receive, send)
 
-    mcp_endpoint = RequireBearer(handle_mcp)
+    mcp_endpoint = RequireBearer(MCPIdentityMiddleware(handle_mcp))
 
     @contextlib.asynccontextmanager
     async def lifespan(app: Starlette):

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -1208,10 +1208,11 @@ async def _execute_public_tool_for_transport(
 
 
 def _emit_initialize(server: Server) -> None:
-    """Bind the current session's client/user identity to the request context and
-    emit an ``mcp.connection`` + ``mcp.handshake`` event (deduped per session in the
-    telemetry layer). Best-effort: any failure to read the request context is
-    swallowed."""
+    """Refine the request identity from the MCP session's negotiated client params
+    when they are available. On the hosted stateless transport they usually are
+    not — each POST is its own session, and connections/handshakes are counted by
+    ``MCPIdentityMiddleware`` in the HTTP layer instead. Best-effort: any failure
+    to read the request context is swallowed."""
     try:
         session = server.request_context.session
         params = session.client_params
@@ -1230,12 +1231,10 @@ def _emit_initialize(server: Server) -> None:
     except Exception:
         pass
 
-    telemetry.record_connection(
-        session_id=id(session),
+    telemetry.set_request_identity(
         client_name=getattr(client_info, "name", None),
-        client_version=getattr(client_info, "version", None),
-        protocol_version=getattr(params, "protocolVersion", None),
         subject=subject,
+        protocol_version=getattr(params, "protocolVersion", None),
     )
 
 

--- a/src/mcp_server_appwrite/telemetry.py
+++ b/src/mcp_server_appwrite/telemetry.py
@@ -486,7 +486,9 @@ def set_request_identity(
     """Bind the current request's client/user identity to the calling context and
     refresh the rolling activity stores. Contextvars propagate into the worker
     threads that execute tools, so record helpers can label by client."""
-    client = client_name or "unknown"
+    # Never downgrade an identity already bound for this request (e.g. by the
+    # HTTP-layer middleware) to "unknown".
+    client = client_name or _request_client.get()
     _request_client.set(client)
     _request_subject.set(subject)
     if not _enabled:

--- a/tests/unit/test_http_app.py
+++ b/tests/unit/test_http_app.py
@@ -1,11 +1,21 @@
 import asyncio
+import json
 import logging
 import os
 import unittest
 from unittest import mock
 
-from mcp_server_appwrite import auth
-from mcp_server_appwrite.http_app import HealthzAccessLogFilter, _send_401
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from mcp_server_appwrite import auth, telemetry
+from mcp_server_appwrite.http_app import (
+    HealthzAccessLogFilter,
+    MCPIdentityMiddleware,
+    _client_from_user_agent,
+    _find_initialize_params,
+    _send_401,
+)
 
 
 class HealthzAccessLogFilterTests(unittest.TestCase):
@@ -158,6 +168,132 @@ class Send401Tests(unittest.TestCase):
         self.assertIn('error="invalid_token"', challenge)
         self.assertIn('resource_metadata="', challenge)
         self.assertNotIn("scope=", challenge)
+
+
+class ClientFromUserAgentTests(unittest.TestCase):
+    def test_product_token(self):
+        self.assertEqual(
+            _client_from_user_agent("claude-code/2.0.1 (darwin)"), "claude-code"
+        )
+        self.assertEqual(_client_from_user_agent("Cursor/1.2"), "cursor")
+
+    def test_missing_or_garbage(self):
+        self.assertIsNone(_client_from_user_agent(None))
+        self.assertIsNone(_client_from_user_agent(""))
+        self.assertIsNone(_client_from_user_agent("!!"))
+
+
+class FindInitializeParamsTests(unittest.TestCase):
+    def test_single_initialize(self):
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "clientInfo": {"name": "claude-code", "version": "2.0"},
+                },
+            }
+        ).encode()
+        params = _find_initialize_params(body)
+        assert params is not None
+        self.assertEqual(params["clientInfo"]["name"], "claude-code")
+
+    def test_batch_with_initialize(self):
+        body = json.dumps(
+            [
+                {"jsonrpc": "2.0", "method": "notifications/initialized"},
+                {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            ]
+        ).encode()
+        self.assertEqual(_find_initialize_params(body), {})
+
+    def test_non_initialize_and_invalid(self):
+        self.assertIsNone(
+            _find_initialize_params(b'{"jsonrpc":"2.0","method":"tools/call"}')
+        )
+        self.assertIsNone(_find_initialize_params(b"not json"))
+
+
+class MCPIdentityMiddlewareTests(unittest.TestCase):
+    def setUp(self):
+        self.reader = InMemoryMetricReader()
+        provider = MeterProvider(metric_readers=[self.reader])
+        telemetry._instruments.clear()
+        telemetry._build_instruments(provider.get_meter("test"), "http", "test")
+        telemetry._enabled = True
+        self.seen_client: list[str] = []
+
+    def tearDown(self):
+        telemetry._enabled = False
+        telemetry._instruments.clear()
+        with telemetry._active_lock:
+            telemetry._active_users.clear()
+            telemetry._active_sessions.clear()
+            telemetry._active_versions.clear()
+
+    def _run(self, body: bytes, headers: list[tuple[bytes, bytes]]):
+        downstream_bodies: list[bytes] = []
+
+        async def app(scope, receive, send):
+            self.seen_client.append(telemetry.current_client_id())
+            message = await receive()
+            downstream_bodies.append(message.get("body", b""))
+
+        scope = {"type": "http", "method": "POST", "path": "/mcp", "headers": headers}
+        received = [{"type": "http.request", "body": body, "more_body": False}]
+
+        async def receive():
+            return received.pop(0)
+
+        async def send(message):
+            pass
+
+        asyncio.run(MCPIdentityMiddleware(app)(scope, receive, send))
+        return downstream_bodies
+
+    def _points(self, metric_name: str) -> list:
+        data = self.reader.get_metrics_data()
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for metric in sm.metrics:
+                    if metric.name == metric_name:
+                        return list(metric.data.data_points)
+        return []
+
+    def test_initialize_records_connection_and_replays_body(self):
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "clientInfo": {"name": "claude-code", "version": "2.0"},
+                },
+            }
+        ).encode()
+        replayed = self._run(body, [(b"user-agent", b"claude-code/2.0")])
+        self.assertEqual(replayed, [body])
+        connections = self._points("mcp.connection")
+        self.assertEqual(len(connections), 1)
+        self.assertEqual(connections[0].attributes.get("client_id"), "claude-code")
+        handshakes = self._points("mcp.handshake")
+        self.assertEqual(handshakes[0].attributes.get("status"), "success")
+
+    def test_tool_call_binds_identity_from_headers(self):
+        body = b'{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{}}'
+        self._run(
+            body,
+            [
+                (b"user-agent", b"cursor/1.5 (linux)"),
+                (b"mcp-protocol-version", b"2025-06-18"),
+            ],
+        )
+        self.assertEqual(self.seen_client, ["cursor"])
+        # No connection counted for non-initialize requests.
+        self.assertEqual(self._points("mcp.connection"), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #71. Verified on production after v0.8.14: `mcp_connection_total`, `mcp_handshake_total{status="success"}` and `mcp_protocol_version_count` never fired, and all tool calls were labeled `client_id="unknown"`.

**Root cause**: the hosted transport is stateless — each POST is its own MCP session, so `session.client_params` is only populated on the request that carries `initialize` (mcp SDK `session.py:180`), and the SDK answers that request internally before any of our decorated handlers run. Identity therefore never reached the metrics layer.

**Fix**: `MCPIdentityMiddleware` (inside the bearer gate, authenticated requests only):
- buffers + replays the JSON-RPC body; an `initialize` message records a connection + successful handshake with `clientInfo.name`/`protocolVersion`;
- every other request binds `client_id` from the User-Agent product token and the protocol version from the `mcp-protocol-version` header;
- `set_request_identity` never downgrades an already-bound identity to `unknown`.

Tests: middleware body-replay + identity binding, UA parsing, initialize detection (157 unit tests pass); ruff/black/pyright clean.