### PR TITLE
Case-normalize client names in telemetry labels

### DIFF
--- a/src/mcp_server_appwrite/telemetry.py
+++ b/src/mcp_server_appwrite/telemetry.py
@@ -476,6 +476,19 @@ def _build_instruments(meter: Any, transport: str, version: str) -> None:
 
 # --- Request identity ---------------------------------------------------------
 
+_CLIENT_NAME_WHITESPACE = re.compile(r"\s+")
+
+
+def _normalize_client_name(name: str | None) -> str | None:
+    """Canonicalize a client-reported name so one client maps to one
+    ``client_id`` label value. ``clientInfo.name`` arrives raw from the
+    initialize request while User-Agent-derived names are lowercased product
+    tokens, so the same client would otherwise split (``Trae`` vs ``trae``)."""
+    if not name:
+        return None
+    text = _CLIENT_NAME_WHITESPACE.sub("-", str(name).strip().lower())[:64]
+    return text or None
+
 
 def set_request_identity(
     *,
@@ -488,7 +501,7 @@ def set_request_identity(
     threads that execute tools, so record helpers can label by client."""
     # Never downgrade an identity already bound for this request (e.g. by the
     # HTTP-layer middleware) to "unknown".
-    client = client_name or _request_client.get()
+    client = _normalize_client_name(client_name) or _request_client.get()
     _request_client.set(client)
     _request_subject.set(subject)
     if not _enabled:
@@ -691,7 +704,7 @@ def record_connection(
         if len(_seen_sessions) > 100_000:
             _seen_sessions.clear()
             _seen_sessions.add(session_id)
-    client = client_name or "unknown"
+    client = _normalize_client_name(client_name) or "unknown"
     _safe_add(
         "connection",
         1,

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -172,6 +172,33 @@ class SessionTests(TelemetryHarness):
         self.assertEqual(len(handshakes), 1)
         self.assertAttr(handshakes[0], "status", "failure")
 
+    def test_client_names_are_case_normalized(self):
+        # clientInfo.name arrives raw from the initialize request while
+        # User-Agent-derived names are lowercased, so the same client must not
+        # split into two client_id values ("Trae" vs "trae").
+        self.connect(session_id=1, client="Trae", subject="user-a")
+        telemetry.set_request_identity(client_name="trae", subject="user-a")
+        by_client = self.points("mcp.active_sessions.by_client")
+        counts = {p.attributes["client_id"]: p.value for p in by_client}
+        self.assertEqual(counts, {"trae": 1})
+        connections = self.points("mcp.connection")
+        self.assertAttr(connections[0], "client_id", "trae")
+
+    def test_client_name_normalization_shapes(self):
+        cases = {
+            "Trae": "trae",
+            "  Claude Code  ": "claude-code",
+            "cursor": "cursor",
+            "": None,
+            None: None,
+            "   ": None,
+            "X" * 100: "x" * 64,
+        }
+        for raw, expected in cases.items():
+            self.assertEqual(
+                telemetry._normalize_client_name(raw), expected, msg=repr(raw)
+            )
+
 
 class MessageTests(TelemetryHarness):
     def test_message_success(self):


### PR DESCRIPTION
## Summary

The MCP dashboard showed `Trae` and `trae` as two distinct clients in "Active Sessions by Client". The split happens because `client_id` is bound from two sources with different casing rules:

- On the `initialize` request, `clientInfo.name` is used **raw** (`http_app.py` → `record_connection`), e.g. `Trae`.
- On every other request, the name is derived from the User-Agent product token, which is **lowercased** (`_client_from_user_agent`), e.g. `trae`.

So a single client contributes two label values across handshake vs per-request metrics, splitting session counts, connection counts, and tool-call attribution.

## Change

Add `_normalize_client_name()` in `telemetry.py` and apply it at both identity entry points (`set_request_identity`, `record_connection`): strip surrounding whitespace, lowercase, collapse internal whitespace runs to hyphens (matching the product-token shape of UA-derived names), cap at 64 chars. Empty/whitespace-only names still fall through to the existing `unknown` handling.

Normalizing at the telemetry layer (rather than the HTTP middleware) covers every caller and keeps the invariant documented in the module docstring: `client_id` is a small bounded set of client names.

## Tests

- `test_client_names_are_case_normalized` — a `Trae` handshake followed by a `trae` request produces a single `client_id="trae"` session and connection label.
- `test_client_name_normalization_shapes` — table test for casing, whitespace-to-hyphen, empty/None, and length-cap behavior.

Full pre-PR checklist passes: ruff, black, pyright, 168 unit tests.