### PR TITLE
Update README with Antigravity CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,27 @@ re-authenticate, run `/mcp auth appwrite` inside a session.
 </details>
 
 <details>
+<summary><b>Antigravity (CLI & 2.0)</b></summary>
+
+Edit `~/.gemini/config/mcp_config.json` (global) or `.agents/mcp_config.json` (project workspace).
+
+```json
+{
+  "mcpServers": {
+    "appwrite": {
+      "serverUrl": "https://mcp.appwrite.io/mcp"
+    }
+  }
+}
+```
+
+> ⚠️ **Note:** Antigravity strictly requires the `serverUrl` key for remote transport. Using legacy fields like `url` or `httpUrl` will cause tool registration to fail silently.
+
+Antigravity opens the browser OAuth flow automatically on first connect. If you manually edit the JSON file, navigate to **Settings → Customizations → Installed MCP Servers** and click **Refresh** to reload the tool definitions.
+
+</details>
+
+<details>
 <summary><b>GitHub Copilot CLI</b></summary>
 
 ```bash


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to ma
This pull request adds documentation for configuring Antigravity CLI 2.0 with MCP servers, including important notes on required configuration fields and instructions for refreshing tool definitions after manual edits.

**Antigravity CLI Configuration:**

* Added a new section in `README.md` with instructions for configuring Antigravity CLI 2.0 by editing the `mcp_config.json` file, specifying the required `serverUrl` key for remote transport.
* Included a warning that using legacy fields like `url` or `httpUrl` will cause tool registration to fail silently.
* Provided guidance on refreshing tool definitions in the UI after making manual changes to the configuration file.ke this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?


**Antigravity CLI Configuration:**

* Added a new section in `README.md` with instructions for configuring Antigravity CLI 2.0 by editing the `mcp_config.json` file, specifying the required `serverUrl` key for remote transport.
* Included a warning that using legacy fields like `url` or `httpUrl` will cause tool registration to fail silently.
* Provided guidance on refreshing tool definitions in the UI after making manual changes to the configuration file.ke this change.

## Test Plan

Zero code changes (README only)

## Related PRs and Issues

None related to this.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes