### PR TITLE
(fix): serve legacy OAuth discovery endpoints for 2025-03-26 MCP clients

### DIFF
--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -5,7 +5,14 @@ Builds a single-tenant Starlette ASGI app for the served Appwrite project:
 * ``/mcp`` — the MCP Streamable-HTTP endpoint, gated by a bearer-token check that
   returns an RFC 9728 ``WWW-Authenticate`` challenge when unauthenticated.
 * ``/.well-known/oauth-protected-resource/mcp`` — RFC 9728 protected resource
-  metadata pointing at the project's Appwrite OAuth authorization server.
+  metadata pointing at the project's Appwrite OAuth authorization server. Also
+  served at the root form (no ``/mcp`` suffix) for clients that don't apply
+  path insertion.
+* ``/.well-known/oauth-authorization-server`` — backwards-compatibility shim for
+  clients on the 2025-03-26 MCP authorization spec (e.g. Raycast), which expect
+  authorization-server metadata at the MCP server's own origin instead of
+  following ``resource_metadata`` from the 401 challenge. Mirrors the Appwrite
+  authorization server's discovery document verbatim.
 * ``/healthz`` — liveness probe.
 
 Auth uses the SDK primitives (``BearerAuthBackend`` + ``AuthContextMiddleware``) so the
@@ -42,6 +49,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from . import error_monitoring, telemetry
 from .auth import (
     AppwriteTokenVerifier,
+    authorization_server_metadata,
     protected_resource_metadata,
     public_base_url,
     resource_metadata_url,
@@ -291,6 +299,19 @@ async def protected_resource_metadata_endpoint(request: Request) -> JSONResponse
     return JSONResponse(metadata, headers=headers)
 
 
+async def authorization_server_metadata_endpoint(request: Request) -> JSONResponse:
+    """Legacy discovery shim (MCP authorization spec 2025-03-26).
+
+    Older clients fetch authorization-server metadata from the MCP server's own
+    origin rather than the ``authorization_servers`` entry in the protected
+    resource metadata. Serve the Appwrite authorization server's discovery
+    document verbatim so those clients find the real authorize/token/register
+    endpoints (the ``issuer`` inside points at the Appwrite endpoint, not here).
+    """
+    metadata = await authorization_server_metadata()
+    return JSONResponse(metadata, headers=dict(CORS_HEADERS))
+
+
 async def health_endpoint(request: Request) -> PlainTextResponse:
     return PlainTextResponse(f"appwrite-mcp {SERVER_VERSION} ok")
 
@@ -337,6 +358,19 @@ def build_app() -> Starlette:
         Route(
             "/.well-known/oauth-protected-resource/mcp",
             endpoint=protected_resource_metadata_endpoint,
+            methods=["GET", "OPTIONS"],
+        ),
+        # Root form, for clients that don't apply RFC 9728 path insertion.
+        Route(
+            "/.well-known/oauth-protected-resource",
+            endpoint=protected_resource_metadata_endpoint,
+            methods=["GET", "OPTIONS"],
+        ),
+        # Legacy 2025-03-26 MCP clients (e.g. Raycast) discover the
+        # authorization server at the MCP origin itself.
+        Route(
+            "/.well-known/oauth-authorization-server",
+            endpoint=authorization_server_metadata_endpoint,
             methods=["GET", "OPTIONS"],
         ),
         Route("/favicon.svg", endpoint=favicon_svg_endpoint, methods=["GET"]),

--- a/tests/unit/test_http_app.py
+++ b/tests/unit/test_http_app.py
@@ -15,6 +15,9 @@ from mcp_server_appwrite.http_app import (
     _client_from_user_agent,
     _find_initialize_params,
     _send_401,
+    authorization_server_metadata_endpoint,
+    build_app,
+    protected_resource_metadata_endpoint,
 )
 
 
@@ -168,6 +171,62 @@ class Send401Tests(unittest.TestCase):
         self.assertIn('error="invalid_token"', challenge)
         self.assertIn('resource_metadata="', challenge)
         self.assertNotIn("scope=", challenge)
+
+
+class WellKnownMetadataEndpointTests(unittest.TestCase):
+    """Discovery endpoints, including the legacy shims for clients on the
+    2025-03-26 MCP authorization spec (e.g. Raycast) that fetch
+    ``/.well-known/oauth-authorization-server`` from the MCP origin instead of
+    following ``resource_metadata`` from the 401 challenge."""
+
+    ENV = {
+        "APPWRITE_ENDPOINT": "https://cloud.appwrite.io/v1",
+        "MCP_PUBLIC_URL": "https://mcp.appwrite.io",
+        "APPWRITE_PROJECT_ID": "console",
+    }
+    DISCOVERY = {
+        "issuer": "https://cloud.appwrite.io/v1/oauth2/console",
+        "authorization_endpoint": "https://cloud.appwrite.io/v1/oauth2/console/authorize",
+        "token_endpoint": "https://cloud.appwrite.io/v1/oauth2/console/token",
+        "registration_endpoint": "https://cloud.appwrite.io/v1/oauth2/console/register",
+        "jwks_uri": "https://cloud.appwrite.io/v1/oauth2/console/.well-known/jwks.json",
+        "scopes_supported": ["openid", "all"],
+    }
+
+    def setUp(self):
+        patcher = mock.patch.dict(os.environ, self.ENV, clear=False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        auth._store_discovery("console", dict(self.DISCOVERY))
+        self.addCleanup(lambda: auth._discovery_cache.pop("console", None))
+
+    def _body(self, response) -> dict:
+        return json.loads(response.body)
+
+    def test_authorization_server_metadata_mirrors_discovery(self):
+        response = asyncio.run(authorization_server_metadata_endpoint(mock.Mock()))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._body(response), self.DISCOVERY)
+        self.assertIn("access-control-allow-origin", response.headers)
+
+    def test_protected_resource_metadata_names_canonical_resource(self):
+        response = asyncio.run(protected_resource_metadata_endpoint(mock.Mock()))
+        self.assertEqual(response.status_code, 200)
+        body = self._body(response)
+        self.assertEqual(body["resource"], "https://mcp.appwrite.io/mcp")
+        self.assertEqual(body["authorization_servers"], [self.DISCOVERY["issuer"]])
+
+    def test_app_routes_include_legacy_discovery_paths(self):
+        # build_mcp_server flips the module-global upload transport to "http";
+        # restore it so stdio-transport tests elsewhere keep seeing the default.
+        from mcp_server_appwrite import server as server_module
+
+        original_transport = server_module._UPLOAD_TRANSPORT
+        self.addCleanup(setattr, server_module, "_UPLOAD_TRANSPORT", original_transport)
+        paths = {getattr(route, "path", None) for route in build_app().routes}
+        self.assertIn("/.well-known/oauth-protected-resource/mcp", paths)
+        self.assertIn("/.well-known/oauth-protected-resource", paths)
+        self.assertIn("/.well-known/oauth-authorization-server", paths)
 
 
 class ClientFromUserAgentTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

Connecting Raycast to `https://mcp.appwrite.io/mcp` fails with:

> Invalid response: not found

A logging proxy showed Raycast (1.104.21) implements the **2025-03-26** MCP authorization spec: after the 401 it ignores the `resource_metadata` URL in `WWW-Authenticate` and instead fetches authorization-server metadata from the MCP origin itself:

```
POST /mcp -> 401   (initialize, clientInfo com.raycast.macos/1.104.21, protocolVersion 2025-03-26)
GET /.well-known/oauth-authorization-server -> 404   ← Raycast aborts here
```

## Fix

Add the backwards-compatibility shim the current MCP spec recommends for exactly this case:

- `/.well-known/oauth-authorization-server` — mirrors the Appwrite authorization server's discovery document verbatim (already fetched and cached by `auth.authorization_server_metadata()`), so legacy clients find the real authorize/token/register endpoints.
- `/.well-known/oauth-protected-resource` (root form) — same handler as the existing `/mcp`-suffixed route, for clients that don't apply RFC 9728 path insertion.

## Verification

- Ran the HTTP transport locally; all three well-known endpoints return the expected documents with CORS headers.
- Unit tests for both endpoints + route registration (including restoring the `_UPLOAD_TRANSPORT` module global that `build_app()` flips, so the stdio-path tests keep passing).
- `ruff`, `black --check`, `pyright`, and the full unit suite (165 tests) pass.

## Note

This gets legacy clients through discovery and the OAuth flow. If Raycast then fails post-login with a 401, the next (separate) issue would be RFC 8707 audience binding — 2025-03-26 clients don't send the `resource` parameter, and `AppwriteTokenVerifier` hard-rejects tokens not audience-bound to `https://mcp.appwrite.io/mcp`.