### PR TITLE
Preserve MCP Registry ownership marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![MCP Registry Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fio.github.appwrite%252Fmcp%2Fversions%2Flatest&query=%24.server.version&label=MCP%20Registry&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/?q=io.github.appwrite%2Fmcp)
 
+<!-- mcp-name: io.github.appwrite/mcp -->
+
 A [Model Context Protocol](https://modelcontextprotocol.io) server for Appwrite.
 It exposes Appwrite's API — databases, users, functions, teams, storage, and more
 — as tools your MCP client can call.


### PR DESCRIPTION
## Summary

- restore the MCP Registry PyPI ownership marker as an invisible README comment
- keep the rendered README visually clean while allowing registry publication

## Testing

- built the wheel and verified its package metadata contains the ownership marker
- `git diff --check`

## Related issue

N/A
