### PR TITLE
Add glama.json for Glama MCP registry claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["ChiragAgg5k"]
+}


### PR DESCRIPTION
## Summary
- Add `glama.json` with maintainer `ChiragAgg5k` so the [Appwrite MCP Glama listing](https://glama.ai/mcp/servers/appwrite/mcp) can be claimed
- Needed to configure Glama's Dockerfile admin settings and pass maintenance checks required by [awesome-mcp-servers#10201](https://github.com/punkpeye/awesome-mcp-servers/pull/10201)

## Test plan
- [ ] After merge, claim the server on Glama (Login with GitHub)
- [ ] Configure Dockerfile in Glama admin and confirm maintenance check passes

Made with [Cursor](https://cursor.com)