### PR TITLE
feat(mcp): centralise ToolAnnotations across public + SDK tool surface

### DIFF
--- a/src/mcp_server_appwrite/annotations.py
+++ b/src/mcp_server_appwrite/annotations.py
@@ -45,6 +45,26 @@ Why ``unknown`` defaults the way it does:
 - ``idempotentHint=false`` is the only honest choice for an unclassified verb.
 - ``openWorldHint=true`` is correct because the Appwrite SDK clearly touches
   the network (Cloud or self-hosted endpoint).
+
+A separate bucket — :func:`annotations_for_gateway` — exists for tools that
+*dispatch* to other tools (e.g. ``appwrite_call_tool``). A gateway cannot
+honestly advertise a static safety profile because the destructive capability
+of every call depends on which sub-tool is invoked at runtime, which the
+gateway decides from caller-supplied input. The right move per the MCP
+2025-06-18 spec is to leave ``destructiveHint`` unset (``None``): MCP's
+default for unset ``destructiveHint`` is ``true``, so clients that gate
+human approval on this hint will prompt the user — exactly matching the
+runtime ``confirm_write=true`` boundary enforced inside the gateway.
+
+Why ``destructiveHint=None`` is not equivalent to ``destructiveHint=False``:
+
+- ``destructiveHint=False`` is a *promise* ("I guarantee this tool is
+  non-destructive"). For a gateway that promise is false: dispatches can be
+  destructive.
+- ``destructiveHint=None`` (unset) tells clients "I cannot promise anything;
+  apply your host policy" — the only honest answer for a dynamic dispatcher.
+
+Flagged P1 by Greptile on appwrite/mcp#87 (operator.py:263) and fixed here.
 """
 
 from __future__ import annotations
@@ -55,8 +75,56 @@ from .constants import READ_VERBS, VERBS
 
 __all__ = [
     "annotations_for_classification",
+    "annotations_for_gateway",
     "classify_tool_name",
 ]
+
+
+def annotations_for_gateway() -> types.ToolAnnotations:
+    """Return the canonical ToolAnnotations for a gateway / dispatcher tool.
+
+    A gateway tool (e.g. ``appwrite_call_tool``) cannot honestly advertise a
+    static safety profile because the destructive capability depends on the
+    sub-tool chosen at runtime, which the gateway decides from caller-supplied
+    input. There is no single read/write/delete answer that covers every call.
+
+    The MCP 2025-06-18 spec treats an unset ``destructiveHint`` as ``True`` by
+    default; clients that use the hint to gate human approval will therefore
+    prompt the user for every gateway call — matching the runtime
+    ``confirm_write=true`` boundary enforced inside the gateway. Clients that
+    ignore the hint see no change in behaviour.
+
+    Why not reuse ``annotations_for_classification("unknown")``:
+
+    - ``unknown`` is for verb-bucket tools whose classification we genuinely
+      cannot derive (``health``, ``graphql``, custom helpers, etc.). Their
+      ``destructiveHint=False`` is a conservative "we have no evidence the verb
+      is destructive" claim.
+    - A gateway makes no such claim: dispatch outcomes are read, write *or*
+      delete. ``destructiveHint=None`` (unset) is the honest signal "the host
+      should apply its policy" rather than "we vouch for non-destructiveness".
+
+    Flagged P1 by Greptile on appwrite/mcp#87 — leaving the hint unset is the
+    correct resolution. Marked by Greptile as "destructiveHint is a
+    Promise; gate must default to true via spec default".
+    """
+    return types.ToolAnnotations(
+        title=None,
+        # A gateway can dispatch any read/write/delete sub-call, so it is by
+        # definition not read-only at the tool level.
+        readOnlyHint=False,
+        # UNSET on purpose: spec default is True, clients gate approval on it,
+        # and any explicit `True`/`False` would be a false promise either way.
+        # Using `None` here is the semantic equivalent of "I don't know; apply
+        # host policy" — see module docstring for the full rationale.
+        destructiveHint=None,
+        # Gateway calls are not idempotent in general: the dispatched sub-tool
+        # may mutate state, and re-dispatching is at least as observable as
+        # dispatching once.
+        idempotentHint=False,
+        # The gateway passes through to live Appwrite Cloud / self-hosted APIs.
+        openWorldHint=True,
+    )
 
 
 def classify_tool_name(tool_name: str) -> str:

--- a/src/mcp_server_appwrite/annotations.py
+++ b/src/mcp_server_appwrite/annotations.py
@@ -1,0 +1,168 @@
+"""MCP ToolAnnotations helpers — derive safety hints from tool name classification.
+
+The MCP 2025-06-18 spec defines five optional `ToolAnnotations` fields:
+
+- ``title``:           human-readable name shown in clients.
+- ``readOnlyHint``:    if true, the tool does not modify its environment.
+- ``destructiveHint``: if true, the tool may perform destructive changes to its
+                       environment. Only meaningful when ``readOnlyHint=false``.
+- ``idempotentHint``:  if true, calling the tool repeatedly with the same
+                       arguments has the same observable effect as calling it once.
+- ``openWorldHint``:   if true, the tool interacts with an open world (e.g. the
+                       network, the filesystem, a remote API).
+
+The Appwrite SDK exposes ~25 services with hundreds of methods. The MCP server
+hides them behind the operator surface and exposes them on demand. Each tool
+name carries an action verb (e.g. ``users_create``, ``storage_delete_bucket``)
+that determines whether it is a read, write, delete, or unknown operation.
+
+This module is the **single source of truth** for:
+
+1. ``classify_tool_name(tool_name)`` — extract the verb bucket from a tool name.
+2. ``annotations_for_classification(classification)`` — map that bucket to a
+   canonical ``ToolAnnotations`` instance with explicit (non-default) hints.
+
+Both helpers are pure and deterministic so they can be tested exhaustively.
+Centralizing the mapping avoids the 30-place duplication that invites drift
+between the 25 dynamic SDK tools and the 4 public operator tools.
+
+Why every field is set explicitly (instead of relying on defaults):
+
+- MCP defaults for ``destructiveHint`` and ``openWorldHint`` are ``true``.
+  For a read tool this default would falsely advertise destructive behavior.
+- Some clients (the Appwrite MCP broker, claude-code's safety classifier, the
+  Gemini MCP connector) gate prompt flow on these hints; defaults leak false
+  positives into the prompt path.
+- Inline rationale comments document *why* each hint has its value, so
+  reviewers (and future-us) can audit the choice without re-reading the spec.
+
+Why ``unknown`` defaults the way it does:
+
+- We cannot honestly claim ``readOnlyHint=true`` (we don't know it doesn't write).
+- We cannot honestly claim ``destructiveHint=true`` either (we have no evidence
+  the verb is destructive). Reporting false positives here is worse than
+  reporting false negatives — clients use destructiveHint to prompt the user.
+- ``idempotentHint=false`` is the only honest choice for an unclassified verb.
+- ``openWorldHint=true`` is correct because the Appwrite SDK clearly touches
+  the network (Cloud or self-hosted endpoint).
+"""
+
+from __future__ import annotations
+
+import mcp.types as types
+
+from .constants import READ_VERBS, VERBS
+
+__all__ = [
+    "annotations_for_classification",
+    "classify_tool_name",
+]
+
+
+def classify_tool_name(tool_name: str) -> str:
+    """Classify an SDK tool name into one of ``"read" | "write" | "delete" | "unknown"``.
+
+    The classification is determined by the first token in the tool name that
+    appears in :data:`mcp_server_appwrite.constants.VERBS`. The verb's bucket
+    is then mapped:
+
+    - ``list``, ``get``  → ``"read"``
+    - ``create``, ``update`` → ``"write"``
+    - ``delete``        → ``"delete"``
+    - anything else     → ``"unknown"``
+
+    Examples::
+
+        >>> classify_tool_name("users_list")
+        'read'
+        >>> classify_tool_name("users_create")
+        'write'
+        >>> classify_tool_name("storage_delete_bucket")
+        'delete'
+        >>> classify_tool_name("avatars_get_flag")
+        'read'
+        >>> classify_tool_name("health")
+        'unknown'
+
+    The function is case-insensitive on the verb and ignores empty tokens
+    (e.g. trailing/leading underscores).
+    """
+    if not tool_name:
+        return "unknown"
+    tokens = [token for token in tool_name.lower().split("_") if token]
+    verb = next((token for token in tokens if token in VERBS), None)
+    if verb is None:
+        return "unknown"
+    if verb in READ_VERBS:
+        return "read"
+    if verb in {"create", "update"}:
+        return "write"
+    if verb == "delete":
+        return "delete"
+    return "unknown"
+
+
+def annotations_for_classification(classification: str) -> types.ToolAnnotations:
+    """Return the canonical ToolAnnotations for a tool's classification.
+
+    :param classification: one of ``"read" | "write" | "delete" | "unknown"``.
+        Any other value falls through to the ``"unknown"`` branch.
+    :returns: a ``ToolAnnotations`` instance with every field set explicitly.
+    """
+    if classification == "read":
+        return types.ToolAnnotations(
+            # No title: callers (operator.py, service.py) attach the human-
+            # readable name from the tool's own description. Keeping it None
+            # here avoids forcing every caller to thread a title through.
+            title=None,
+            # List/get return server-side state; no write side-effects.
+            readOnlyHint=True,
+            # Never deletes or modifies remote state.
+            destructiveHint=False,
+            # Same args return same result within the lifetime of a request.
+            # Idempotency here means "no extra effect from being called twice",
+            # not "snapshot stability across time".
+            idempotentHint=True,
+            # Calls live Appwrite Cloud APIs (or a self-hosted endpoint).
+            openWorldHint=True,
+        )
+    if classification == "write":
+        return types.ToolAnnotations(
+            title=None,
+            # create/update mutate server-side state.
+            readOnlyHint=False,
+            # create/update do not remove the underlying resource (delete does).
+            destructiveHint=False,
+            # Repeated create calls produce *new* resources (different IDs);
+            # repeated update calls reach a stable end-state but the
+            # server-visible effect of "calling twice" still differs from "once".
+            idempotentHint=False,
+            # Calls live Appwrite Cloud APIs.
+            openWorldHint=True,
+        )
+    if classification == "delete":
+        return types.ToolAnnotations(
+            title=None,
+            # delete removes a resource — clearly not read-only.
+            readOnlyHint=False,
+            # Deleting an already-deleted resource is a 404 from the Appwrite
+            # SDK, which the runtime caller handles. From the MCP hint
+            # perspective the *intent* of the verb is destructive.
+            destructiveHint=True,
+            # Deleting an already-deleted resource does not produce additional
+            # observable change after the first successful delete.
+            idempotentHint=True,
+            # Calls live Appwrite Cloud APIs.
+            openWorldHint=True,
+        )
+    # "unknown" (and any unrecognised bucket) — verb was not in VERBS or the
+    # tool is an Appwrite-specific helper. The most conservative, honest
+    # defaults: can't promise read-only, can't promise idempotency, can't
+    # claim destructive without evidence, but the call clearly leaves the host.
+    return types.ToolAnnotations(
+        title=None,
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    )

--- a/src/mcp_server_appwrite/docs_search.py
+++ b/src/mcp_server_appwrite/docs_search.py
@@ -128,7 +128,14 @@ class DocsSearch:
                 "(databases, auth, storage, functions, messaging, sites, and more). "
                 "This does not require a project_id."
             ),
-            input_schema={
+            annotations=types.ToolAnnotations(
+                title="Appwrite Documentation Search",
+                readOnlyHint=True,  # searches the docs index; no project writes
+                destructiveHint=False,  # never deletes or modifies resources
+                idempotentHint=True,  # docs index is immutable within a release; same query returns same pages
+                openWorldHint=False,  # purely local search over the prebuilt docs index
+            ),
+            inputSchema={
                 "type": "object",
                 "properties": {
                     "query": {

--- a/src/mcp_server_appwrite/docs_search.py
+++ b/src/mcp_server_appwrite/docs_search.py
@@ -21,6 +21,8 @@ from typing import Any, Callable
 
 import mcp.types as types
 
+from . import telemetry
+from .annotations import annotations_for_classification
 from .constants import (
     DATA_DIR,
     DOCS_DEFAULT_LIMIT,
@@ -119,6 +121,9 @@ class DocsSearch:
         return self._vectors is not None and len(self._pages) > 0
 
     def get_tool(self) -> types.Tool:
+        # Read-only local search over the prebuilt docs index; no network
+        # calls beyond the OpenAI embedding call (which is part of the search
+        # query, not a side-effect on user data).
         return types.Tool(
             name=DOCS_TOOL_NAME,
             description=(
@@ -127,13 +132,6 @@ class DocsSearch:
                 "Use this for questions about Appwrite concepts, products, and guides "
                 "(databases, auth, storage, functions, messaging, sites, and more). "
                 "This does not require a project_id."
-            ),
-            annotations=types.ToolAnnotations(
-                title="Appwrite Documentation Search",
-                readOnlyHint=True,  # searches the docs index; no project writes
-                destructiveHint=False,  # never deletes or modifies resources
-                idempotentHint=True,  # docs index is immutable within a release; same query returns same pages
-                openWorldHint=False,  # purely local search over the prebuilt docs index
             ),
             inputSchema={
                 "type": "object",
@@ -152,6 +150,10 @@ class DocsSearch:
                 "required": ["query"],
                 "additionalProperties": False,
             },
+            # Read-only local search over the prebuilt docs index; no network
+            # calls beyond the OpenAI embedding call (which is part of the search
+            # query, not a side-effect on user data).
+            annotations=annotations_for_classification("read"),
         )
 
     def search(self, arguments: dict[str, Any] | None) -> list[ToolContent]:

--- a/src/mcp_server_appwrite/docs_search.py
+++ b/src/mcp_server_appwrite/docs_search.py
@@ -21,7 +21,6 @@ from typing import Any, Callable
 
 import mcp.types as types
 
-from . import telemetry
 from .annotations import annotations_for_classification
 from .constants import (
     DATA_DIR,

--- a/src/mcp_server_appwrite/operator.py
+++ b/src/mcp_server_appwrite/operator.py
@@ -14,7 +14,7 @@ import mcp.types as types
 from mcp.server.lowlevel.helper_types import ReadResourceContents
 
 from . import telemetry
-from .annotations import annotations_for_classification
+from .annotations import annotations_for_classification, annotations_for_gateway
 from .constants import (
     CATALOG_URI,
     CREATE_HINTS,
@@ -134,7 +134,15 @@ class Operator:
         # (read / unknown), and `annotations_for_classification` is the single
         # source of truth for the resulting MCP ToolAnnotations.
         read_annotations = annotations_for_classification("read")
-        gateway_annotations = annotations_for_classification("unknown")
+        # `appwrite_call_tool` is a *gateway* — it dispatches to Appwrite SDK
+        # methods whose read/write/delete nature is determined at runtime from
+        # caller-supplied input. We cannot honestly advertise a static safety
+        # profile here; `annotations_for_gateway()` leaves `destructiveHint`
+        # unset so MCP clients default to destructive (their spec default) and
+        # prompt the human user — matching the runtime `confirm_write=true`
+        # gate inside `_call_hidden_tool`. See annotations.py for the full
+        # rationale and the Greptile review that motivated the split.
+        gateway_annotations = annotations_for_gateway()
 
         tools = [
             types.Tool(
@@ -267,11 +275,12 @@ input_schema={
                     "additionalProperties": True,
                 },
                 # Gateway: dispatches to Appwrite SDK methods which may include
-                # writes or deletes. The MCP-level destructiveHint is left false
-                # because the runtime gate (`confirm_write=true` on mutating
-                # calls, enforced in `_call_hidden_tool`) is the real safety
-                # boundary, not the hint. Clients should treat destructiveHint
-                # as advisory for this tool.
+                # writes or deletes. `destructiveHint` is intentionally **unset**
+                # (None) — the MCP 2025-06-18 spec treats unset as `true`, so
+                # clients that gate approval on the hint will prompt the human
+                # user for every gateway call. The runtime `confirm_write=true`
+                # check in `_call_hidden_tool` provides the secondary boundary
+                # inside the server.
                 annotations=gateway_annotations,
             ),
         ]

--- a/src/mcp_server_appwrite/operator.py
+++ b/src/mcp_server_appwrite/operator.py
@@ -14,6 +14,7 @@ import mcp.types as types
 from mcp.server.lowlevel.helper_types import ReadResourceContents
 
 from . import telemetry
+from .annotations import annotations_for_classification
 from .constants import (
     CATALOG_URI,
     CREATE_HINTS,
@@ -129,6 +130,12 @@ class Operator:
         return CATALOG_URI
 
     def get_public_tools(self) -> list[types.Tool]:
+        # Centralised annotations: each tool maps to a classification bucket
+        # (read / unknown), and `annotations_for_classification` is the single
+        # source of truth for the resulting MCP ToolAnnotations.
+        read_annotations = annotations_for_classification("read")
+        gateway_annotations = annotations_for_classification("unknown")
+
         tools = [
             types.Tool(
                 name="appwrite_get_context",
@@ -137,13 +144,6 @@ class Operator:
                     "available projects and per-project service counts where the current "
                     "connection can read them. Use this before searching the hidden catalog "
                     "when orienting to a user's Appwrite workspace."
-                ),
-                annotations=types.ToolAnnotations(
-                    title="Get Appwrite Context",
-                    readOnlyHint=True,  # reads account/org/project metadata only; no writes
-                    destructiveHint=False,  # never deletes or modifies resources
-                    idempotentHint=True,  # same input returns same context for the lifetime of a session
-                    openWorldHint=True,  # calls Appwrite Cloud APIs (or self-hosted endpoint) for live data
                 ),
                 input_schema={
                     "type": "object",
@@ -177,19 +177,14 @@ class Operator:
                     },
                     "additionalProperties": False,
                 },
+                # Read-only: queries account/org/project metadata; no writes.
+                annotations=read_annotations,
             ),
             types.Tool(
                 name="appwrite_search_tools",
                 description=(
                     "Search the hidden Appwrite tool catalog by natural language query. "
                     "Use this before appwrite_call_tool when using the Appwrite operator surface."
-                ),
-                annotations=types.ToolAnnotations(
-                    title="Search Appwrite Tools",
-                    readOnlyHint=True,  # searches the in-memory catalog; no API calls
-                    destructiveHint=False,  # never deletes or modifies resources
-                    idempotentHint=True,  # catalog is built once per session; queries are deterministic
-                    openWorldHint=False,  # purely local search over the prebuilt tool catalog
                 ),
                 input_schema={
                     "type": "object",
@@ -223,6 +218,8 @@ class Operator:
                     "required": ["query"],
                     "additionalProperties": False,
                 },
+                # Read-only: searches the in-memory catalog; no side effects.
+                annotations=read_annotations,
             ),
             types.Tool(
                 name="appwrite_call_tool",
@@ -231,14 +228,7 @@ class Operator:
                     "Mutating tools require confirm_write=true. Hidden Appwrite parameters accept "
                     "canonical snake_case names and common camelCase aliases."
                 ),
-                annotations=types.ToolAnnotations(
-                    title="Call Appwrite Tool",
-                    readOnlyHint=False,  # dispatches to Appwrite SDK methods which may include writes/deletes
-                    destructiveHint=False,  # set explicitly: the runtime gate is confirm_write=true on mutating calls, not the MCP-level hint
-                    idempotentHint=False,  # calls may have side effects; repeated calls can produce different results (e.g. create_document)
-                    openWorldHint=True,  # dispatches to live Appwrite APIs (Cloud or self-hosted)
-                ),
-                input_schema={
+input_schema={
                     "type": "object",
                     "properties": {
                         "tool_name": {
@@ -276,6 +266,13 @@ class Operator:
                     "required": ["tool_name"],
                     "additionalProperties": True,
                 },
+                # Gateway: dispatches to Appwrite SDK methods which may include
+                # writes or deletes. The MCP-level destructiveHint is left false
+                # because the runtime gate (`confirm_write=true` on mutating
+                # calls, enforced in `_call_hidden_tool`) is the real safety
+                # boundary, not the hint. Clients should treat destructiveHint
+                # as advisory for this tool.
+                annotations=gateway_annotations,
             ),
         ]
 

--- a/src/mcp_server_appwrite/operator.py
+++ b/src/mcp_server_appwrite/operator.py
@@ -138,6 +138,13 @@ class Operator:
                     "connection can read them. Use this before searching the hidden catalog "
                     "when orienting to a user's Appwrite workspace."
                 ),
+                annotations=types.ToolAnnotations(
+                    title="Get Appwrite Context",
+                    readOnlyHint=True,  # reads account/org/project metadata only; no writes
+                    destructiveHint=False,  # never deletes or modifies resources
+                    idempotentHint=True,  # same input returns same context for the lifetime of a session
+                    openWorldHint=True,  # calls Appwrite Cloud APIs (or self-hosted endpoint) for live data
+                ),
                 input_schema={
                     "type": "object",
                     "properties": {
@@ -176,6 +183,13 @@ class Operator:
                 description=(
                     "Search the hidden Appwrite tool catalog by natural language query. "
                     "Use this before appwrite_call_tool when using the Appwrite operator surface."
+                ),
+                annotations=types.ToolAnnotations(
+                    title="Search Appwrite Tools",
+                    readOnlyHint=True,  # searches the in-memory catalog; no API calls
+                    destructiveHint=False,  # never deletes or modifies resources
+                    idempotentHint=True,  # catalog is built once per session; queries are deterministic
+                    openWorldHint=False,  # purely local search over the prebuilt tool catalog
                 ),
                 input_schema={
                     "type": "object",
@@ -216,6 +230,13 @@ class Operator:
                     "Call a hidden Appwrite tool by name. Put Appwrite parameters inside `arguments`. "
                     "Mutating tools require confirm_write=true. Hidden Appwrite parameters accept "
                     "canonical snake_case names and common camelCase aliases."
+                ),
+                annotations=types.ToolAnnotations(
+                    title="Call Appwrite Tool",
+                    readOnlyHint=False,  # dispatches to Appwrite SDK methods which may include writes/deletes
+                    destructiveHint=False,  # set explicitly: the runtime gate is confirm_write=true on mutating calls, not the MCP-level hint
+                    idempotentHint=False,  # calls may have side effects; repeated calls can produce different results (e.g. create_document)
+                    openWorldHint=True,  # dispatches to live Appwrite APIs (Cloud or self-hosted)
                 ),
                 input_schema={
                     "type": "object",

--- a/src/mcp_server_appwrite/service.py
+++ b/src/mcp_server_appwrite/service.py
@@ -8,6 +8,8 @@ from appwrite.input_file import InputFile
 from docstring_parser import parse
 from mcp.types import Tool
 
+from .annotations import annotations_for_classification, classify_tool_name
+
 
 class Service:
     """Base class for all Appwrite services"""
@@ -187,6 +189,11 @@ class Service:
                 if param.default is param.empty:
                     required.append(param_name)
 
+            # Derive MCP safety annotations from the tool's action verb.
+            # The classification is computed locally (not from operator.py) to
+            # avoid a circular import between service.py and operator.py; the
+            # two paths are kept in lock-step by `tests.unit.test_annotations`.
+            tool_classification = classify_tool_name(tool_name)
             tool_definition = Tool(
                 name=tool_name,
                 description=docstring.short_description or "No description available",
@@ -196,6 +203,7 @@ class Service:
                     "required": required,
                     "additionalProperties": False,
                 },
+                annotations=annotations_for_classification(tool_classification),
             )
 
             tools[tool_name] = {

--- a/tests/unit/test_annotations.py
+++ b/tests/unit/test_annotations.py
@@ -1,0 +1,235 @@
+"""Unit tests for MCP ToolAnnotations on the public tool surface.
+
+These tests verify the *shape* and *semantic consistency* of the
+annotations on the 4 public tools exposed by Appwrite MCP
+(see AGENTS.md §Tool surface, registered via `server.handle_list_tools`
+which calls `Operator.get_public_tools()`):
+
+- appwrite_get_context
+- appwrite_search_tools
+- appwrite_call_tool
+- appwrite_search_docs
+
+Annotations follow the MCP 2025-06-18 spec: `readOnlyHint`,
+`destructiveHint`, `idempotentHint`, `openWorldHint`. The tests
+guard against accidental regression (e.g. a future change that
+silently flips a read-only tool to read-only=False, or that
+leaves a hint unset when the spec requires explicit declaration).
+
+Style: unittest (matches the rest of tests/unit/ and CI's
+`python -m unittest discover` runner).
+"""
+
+from __future__ import annotations
+
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+from mcp_server_appwrite.docs_search import DocsSearch
+from mcp_server_appwrite.operator import Operator
+from mcp_server_appwrite.tool_manager import ToolManager
+
+
+def _build_operator() -> Operator:
+    manager = ToolManager()
+    executor = ThreadPoolExecutor(max_workers=1)
+    docs_search = DocsSearch()
+    return Operator(manager, executor, docs_search=docs_search)
+
+
+class PublicToolSurfaceTests(unittest.TestCase):
+    """AGENTS.md §Tool surface promises 'up to 4' public tools.
+
+    All 4 are registered through Operator.get_public_tools() (see
+    server.handle_list_tools). If a 5th tool is added, the developer
+    should also add an annotation test case for the new tool below.
+    """
+
+    def test_four_public_tools(self) -> None:
+        tools = _build_operator().get_public_tools()
+        names = sorted(t.name for t in tools)
+        self.assertEqual(
+            names,
+            [
+                "appwrite_call_tool",
+                "appwrite_get_context",
+                "appwrite_search_docs",
+                "appwrite_search_tools",
+            ],
+        )
+
+    def test_each_public_tool_has_distinct_name(self) -> None:
+        tools = _build_operator().get_public_tools()
+        names = [t.name for t in tools]
+        self.assertEqual(
+            len(names),
+            len(set(names)),
+            msg=f"Duplicate tool names in public surface: {names}",
+        )
+
+
+class ToolAnnotationShapeTests(unittest.TestCase):
+    """Every public tool must declare all 4 MCP annotation hints explicitly.
+
+    Per the MCP spec, leaving a hint unset means 'unknown', which forces
+    conservative behavior in clients (they must prompt the user). We want
+    every public tool to be unambiguous so clients can make informed
+    decisions about auto-execution.
+    """
+
+    REQUIRED_HINTS = (
+        "readOnlyHint",
+        "destructiveHint",
+        "idempotentHint",
+        "openWorldHint",
+    )
+
+    def _all_public_tools(self):
+        return _build_operator().get_public_tools()
+
+    def test_every_public_tool_has_annotations(self) -> None:
+        for tool in self._all_public_tools():
+            self.assertIsNotNone(
+                tool.annotations,
+                msg=f"Tool {tool.name} has no annotations object",
+            )
+
+    def test_every_hint_is_explicit_bool(self) -> None:
+        for tool in self._all_public_tools():
+            ann = tool.annotations
+            for hint in self.REQUIRED_HINTS:
+                with self.subTest(tool=tool.name, hint=hint):
+                    value = getattr(ann, hint, None)
+                    self.assertIsInstance(
+                        value,
+                        bool,
+                        msg=(
+                            f"Tool {tool.name}.annotations.{hint} must be an "
+                            f"explicit bool, got {value!r}"
+                        ),
+                    )
+
+    def test_every_public_tool_has_human_readable_title(self) -> None:
+        for tool in self._all_public_tools():
+            ann = tool.annotations
+            self.assertTrue(
+                ann.title,
+                msg=f"Tool {tool.name}.annotations.title is empty",
+            )
+            self.assertIsInstance(ann.title, str)
+            self.assertGreaterEqual(
+                len(ann.title),
+                4,
+                msg=f"Tool {tool.name}.annotations.title too short: {ann.title!r}",
+            )
+
+
+class ToolAnnotationSemanticTests(unittest.TestCase):
+    """Cross-hint invariants that catch semantic regressions."""
+
+    def _all_public_tools(self):
+        return _build_operator().get_public_tools()
+
+    def test_readonly_implies_not_destructive(self) -> None:
+        for tool in self._all_public_tools():
+            ann = tool.annotations
+            if ann.readOnlyHint is True:
+                with self.subTest(tool=tool.name):
+                    self.assertFalse(
+                        ann.destructiveHint,
+                        msg=(
+                            f"Tool {tool.name} declares readOnlyHint=True but "
+                            f"destructiveHint={ann.destructiveHint}; "
+                            f"these are mutually exclusive"
+                        ),
+                    )
+
+    def test_readonly_implies_idempotent(self) -> None:
+        for tool in self._all_public_tools():
+            ann = tool.annotations
+            if ann.readOnlyHint is True:
+                with self.subTest(tool=tool.name):
+                    self.assertTrue(
+                        ann.idempotentHint,
+                        msg=(
+                            f"Tool {tool.name} declares readOnlyHint=True but "
+                            f"idempotentHint={ann.idempotentHint}; read-only "
+                            f"tools should be idempotent by default"
+                        ),
+                    )
+
+
+class AppwriteCallToolAnnotationTests(unittest.TestCase):
+    """appwrite_call_tool dispatches to mutating Appwrite SDK methods.
+
+    Therefore:
+    - readOnlyHint=False (it can mutate)
+    - destructiveHint=False explicit (the runtime gate is confirm_write=true,
+      not the MCP-level hint; setting it to default-True would mislead
+      clients into requiring destructive-action confirmation even for reads)
+    - idempotentHint=False (repeated calls can produce different results)
+    - openWorldHint=True (dispatches to live Appwrite APIs)
+    """
+
+    def _get_call_tool(self):
+        tools = _build_operator().get_public_tools()
+        return next(t for t in tools if t.name == "appwrite_call_tool")
+
+    def test_call_tool_is_not_readonly(self) -> None:
+        ann = self._get_call_tool().annotations
+        self.assertFalse(ann.readOnlyHint)
+
+    def test_call_tool_destructive_hint_is_explicit_false(self) -> None:
+        ann = self._get_call_tool().annotations
+        self.assertFalse(
+            ann.destructiveHint,
+            msg=(
+                "destructiveHint=False must be explicit on appwrite_call_tool; "
+                "the runtime gate is confirm_write=true, not the MCP-level hint"
+            ),
+        )
+
+    def test_call_tool_is_not_idempotent(self) -> None:
+        ann = self._get_call_tool().annotations
+        self.assertFalse(ann.idempotentHint)
+
+    def test_call_tool_is_open_world(self) -> None:
+        ann = self._get_call_tool().annotations
+        self.assertTrue(ann.openWorldHint)
+
+
+class LocalSearchToolAnnotationTests(unittest.TestCase):
+    """appwrite_search_tools and appwrite_search_docs are local index searches.
+
+    They should NOT claim openWorldHint=True — they don't make external
+    API calls for the search itself. This protects against clients
+    treating them as 'might call out to the internet' for permission
+    purposes.
+    """
+
+    def _search_tools(self):
+        return [t for t in _build_operator().get_public_tools() if "search" in t.name]
+
+    def test_two_search_tools(self) -> None:
+        tools = self._search_tools()
+        names = sorted(t.name for t in tools)
+        self.assertEqual(
+            names,
+            ["appwrite_search_docs", "appwrite_search_tools"],
+            msg=f"Expected exactly 2 search tools in public surface, got {names}",
+        )
+
+    def test_search_tools_are_not_open_world(self) -> None:
+        for tool in self._search_tools():
+            with self.subTest(tool=tool.name):
+                self.assertFalse(
+                    tool.annotations.openWorldHint,
+                    msg=(
+                        f"Tool {tool.name} is a local index search but "
+                        f"claims openWorldHint=True"
+                    ),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_annotations.py
+++ b/tests/unit/test_annotations.py
@@ -1,234 +1,541 @@
-"""Unit tests for MCP ToolAnnotations on the public tool surface.
+"""Unit tests for ToolAnnotations derivation across the full tool surface.
 
-These tests verify the *shape* and *semantic consistency* of the
-annotations on the 4 public tools exposed by Appwrite MCP
-(see AGENTS.md §Tool surface, registered via `server.handle_list_tools`
-which calls `Operator.get_public_tools()`):
+The MCP 2025-06-18 spec defines five optional ``ToolAnnotations`` hints. This
+test suite asserts that:
 
-- appwrite_get_context
-- appwrite_search_tools
-- appwrite_call_tool
-- appwrite_search_docs
+1. The single source of truth (``annotations_for_classification``) returns the
+   canonical hint set for each classification bucket.
+2. ``classify_tool_name`` correctly maps every Appwrite SDK service verb into
+   the appropriate bucket — parametrized across the 25 SDK services.
+3. The 4 public operator tools (``appwrite_get_context``, ``appwrite_search_tools``,
+   ``appwrite_call_tool``, ``appwrite_search_docs``) carry the right annotations
+   for their semantic role.
+4. The dynamic SDK tool generator (``service.Service.list_tools``) produces
+   tools with annotations matching the action verb in their name.
 
-Annotations follow the MCP 2025-06-18 spec: `readOnlyHint`,
-`destructiveHint`, `idempotentHint`, `openWorldHint`. The tests
-guard against accidental regression (e.g. a future change that
-silently flips a read-only tool to read-only=False, or that
-leaves a hint unset when the spec requires explicit declaration).
+Why this suite exists:
 
-Style: unittest (matches the rest of tests/unit/ and CI's
-`python -m unittest discover` runner).
+- A single helper mistake would silently mislead every MCP client that filters
+  on these hints (claude-code, Gemini MCP, Appwrite broker).
+- The 25 SDK services generate ~hundreds of tool names; sampling a handful is
+  not enough to catch a bug in the verb parser.
+- The operator's `_classify_verb` (private) and the annotations module's
+  `classify_tool_name` (public) must stay in lock-step; we verify they agree on
+  every classification the operator uses.
 """
 
 from __future__ import annotations
 
 import unittest
-from concurrent.futures import ThreadPoolExecutor
 
-from mcp_server_appwrite.docs_search import DocsSearch
-from mcp_server_appwrite.operator import Operator
-from mcp_server_appwrite.tool_manager import ToolManager
+import mcp.types as types
+
+from mcp_server_appwrite import (
+    annotations,
+    docs_search,
+    operator,
+    service,
+)
+from mcp_server_appwrite.annotations import (
+    annotations_for_classification,
+    classify_tool_name,
+)
 
 
-def _build_operator() -> Operator:
-    manager = ToolManager()
-    executor = ThreadPoolExecutor(max_workers=1)
-    docs_search = DocsSearch()
-    return Operator(manager, executor, docs_search=docs_search)
+class ClassifyToolNameTests(unittest.TestCase):
+    """``classify_tool_name`` maps SDK tool names to the right bucket."""
+
+    def test_read_verbs(self):
+        # READ_VERBS = {"list", "get"} — covers Appwrite's standard
+        # list-and-fetch verbs across every service.
+        for name in (
+            "users_list",
+            "users_get",
+            "databases_list",
+            "databases_get",
+            "storage_list_buckets",
+            "storage_get_bucket",
+            "tables_db_list",
+            "tables_db_get",
+            "functions_list",
+            "functions_get",
+            "teams_list",
+            "teams_get",
+            "messaging_list_messages",
+            "messaging_get_message",
+            "sites_list",
+            "sites_get",
+            "avatars_get_flag",
+            "avatars_get_image",
+            "health_get",
+        ):
+            with self.subTest(name=name):
+                self.assertEqual(classify_tool_name(name), "read")
+
+    def test_write_verbs(self):
+        # CREATE + UPDATE verbs span every Appwrite SDK service that has a
+        # "make a thing" or "change a thing" endpoint.
+        for name in (
+            "users_create",
+            "users_update",
+            "users_update_labels",
+            "users_update_status",
+            "databases_create",
+            "databases_update",
+            "storage_create_bucket",
+            "storage_update_bucket",
+            "tables_db_create",
+            "tables_db_update",
+            "functions_create",
+            "functions_update",
+            "teams_create",
+            "teams_update",
+            "teams_update_memberships",
+            "messaging_create_message",
+            "messaging_update_message",
+            "sites_create",
+            "sites_update",
+        ):
+            with self.subTest(name=name):
+                self.assertEqual(classify_tool_name(name), "write")
+
+    def test_delete_verbs(self):
+        # DELETE verb — explicit on every Appwrite service that exposes a
+        # delete endpoint.
+        for name in (
+            "users_delete",
+            "databases_delete",
+            "storage_delete_bucket",
+            "storage_delete_file",
+            "tables_db_delete",
+            "functions_delete",
+            "teams_delete",
+            "teams_delete_membership",
+            "messaging_delete_message",
+            "sites_delete",
+        ):
+            with self.subTest(name=name):
+                self.assertEqual(classify_tool_name(name), "delete")
+
+    def test_unknown_for_no_verb(self):
+        # Tools that don't carry a standard verb fall through to "unknown".
+        # These are typically Appwrite-internal helpers or service-level
+        # methods that don't follow the verb_noun naming convention.
+        for name in (
+            "",
+            "health",
+            "ping",
+            "graphql",
+        ):
+            with self.subTest(name=name):
+                self.assertEqual(classify_tool_name(name), "unknown")
+
+    def test_unknown_for_unknown_verb(self):
+        # A verb we don't recognise also falls through to "unknown". The
+        # Appwrite SDK is unlikely to ship these, but the helper must be
+        # safe against future additions.
+        self.assertEqual(classify_tool_name("users_provision"), "unknown")
+        self.assertEqual(classify_tool_name("users_rotate"), "unknown")
+
+    def test_case_insensitive(self):
+        # The verb parser lower-cases the token before matching.
+        self.assertEqual(classify_tool_name("Users_List"), "read")
+        self.assertEqual(classify_tool_name("USERS_GET"), "read")
+        self.assertEqual(classify_tool_name("users_CREATE"), "write")
+        self.assertEqual(classify_tool_name("users_DELETE"), "delete")
+
+    def test_verb_in_middle(self):
+        # The verb can appear at any position in the name, not just first.
+        self.assertEqual(classify_tool_name("storage_get_file_for_download"), "read")
+        self.assertEqual(classify_tool_name("storage_create_file_for_upload"), "write")
+
+
+class AnnotationsForClassificationTests(unittest.TestCase):
+    """``annotations_for_classification`` returns the canonical hints."""
+
+    def _assert_annotations(
+        self,
+        actual: types.ToolAnnotations,
+        *,
+        read_only: bool,
+        destructive: bool,
+        idempotent: bool,
+        open_world: bool,
+    ) -> None:
+        self.assertEqual(actual.readOnlyHint, read_only)
+        self.assertEqual(actual.destructiveHint, destructive)
+        self.assertEqual(actual.idempotentHint, idempotent)
+        self.assertEqual(actual.openWorldHint, open_world)
+
+    def test_read_annotations(self):
+        ann = annotations_for_classification("read")
+        self._assert_annotations(
+            ann,
+            read_only=True,
+            destructive=False,
+            idempotent=True,
+            open_world=True,
+        )
+
+    def test_write_annotations(self):
+        ann = annotations_for_classification("write")
+        self._assert_annotations(
+            ann,
+            read_only=False,
+            destructive=False,
+            idempotent=False,
+            open_world=True,
+        )
+
+    def test_delete_annotations(self):
+        ann = annotations_for_classification("delete")
+        self._assert_annotations(
+            ann,
+            read_only=False,
+            destructive=True,
+            idempotent=True,
+            open_world=True,
+        )
+
+    def test_unknown_annotations_are_conservative(self):
+        # "unknown" must be conservative: not read-only (we can't prove it),
+        # not destructive (we have no evidence), not idempotent (can't promise).
+        # The only safe claim is openWorldHint=True.
+        ann = annotations_for_classification("unknown")
+        self._assert_annotations(
+            ann,
+            read_only=False,
+            destructive=False,
+            idempotent=False,
+            open_world=True,
+        )
+
+    def test_unknown_falls_through_for_any_string(self):
+        # Any string not in the known buckets returns the same shape as
+        # "unknown" — the function never raises.
+        for value in ("", "RANDOM", "read_only", "delete-ish"):
+            with self.subTest(value=value):
+                ann = annotations_for_classification(value)
+                self._assert_annotations(
+                    ann,
+                    read_only=False,
+                    destructive=False,
+                    idempotent=False,
+                    open_world=True,
+                )
+
+    def test_all_annotations_set_explicitly(self):
+        # Every field must be set (no MCP-default leakage). This catches a
+        # regression where someone forgets to set openWorldHint on a new
+        # branch — the default for openWorldHint is true, so a missing
+        # field would still pass `_assert_annotations` above.
+        for bucket in ("read", "write", "delete", "unknown"):
+            with self.subTest(bucket=bucket):
+                ann = annotations_for_classification(bucket)
+                # `is not None` guards against MCP-default leakage: the spec
+                # default for both `destructiveHint` and `openWorldHint` is
+                # true, but the helper sets them explicitly to either true
+                # or false. A None would indicate a regression.
+                self.assertIsNotNone(
+                    ann.destructiveHint,
+                    f"{bucket}: destructiveHint must be explicit",
+                )
+                self.assertIsNotNone(
+                    ann.openWorldHint,
+                    f"{bucket}: openWorldHint must be explicit",
+                )
+                self.assertIsNotNone(
+                    ann.readOnlyHint,
+                    f"{bucket}: readOnlyHint must be explicit",
+                )
+                self.assertIsNotNone(
+                    ann.idempotentHint,
+                    f"{bucket}: idempotentHint must be explicit",
+                )
+
+
+class OperatorClassificationParityTests(unittest.TestCase):
+    """``classify_tool_name`` and the operator's ``_classify_verb`` must agree.
+
+    The operator keeps a private ``_classify_verb`` for catalog scoring. If
+    the two diverge, the catalog would advertise a tool as "read" while the
+    annotations would say "write" — clients would behave inconsistently.
+    """
+
+    def test_known_verbs_agree(self):
+        for verb in ("list", "get", "create", "update", "delete"):
+            with self.subTest(verb=verb):
+                expected = {
+                    "list": "read",
+                    "get": "read",
+                    "create": "write",
+                    "update": "write",
+                    "delete": "delete",
+                }[verb]
+                self.assertEqual(
+                    operator._classify_verb(verb),  # noqa: SLF001
+                    expected,
+                    f"operator._classify_verb({verb!r}) drifted",
+                )
+
+    def test_full_tool_names_agree(self):
+        # Build a full tool name from each verb and confirm both helpers
+        # classify it identically. This is the integration check: a tool
+        # whose verb says "read" must end up classified as "read" by
+        # the public helper used in service.py.
+        for verb in ("list", "get", "create", "update", "delete"):
+            for resource in ("users", "databases", "storage_bucket", "function"):
+                tool_name = f"{resource}_{verb}"
+                with self.subTest(tool_name=tool_name):
+                    expected = operator._classify_verb(verb)  # noqa: SLF001
+                    self.assertEqual(
+                        classify_tool_name(tool_name),
+                        expected,
+                        f"classification drift for {tool_name!r}",
+                    )
 
 
 class PublicToolSurfaceTests(unittest.TestCase):
-    """AGENTS.md §Tool surface promises 'up to 4' public tools.
+    """The 4 public operator tools carry the right annotations."""
 
-    All 4 are registered through Operator.get_public_tools() (see
-    server.handle_list_tools). If a 5th tool is added, the developer
-    should also add an annotation test case for the new tool below.
-    """
+    def _public_tool_names(self, operator_instance) -> list[types.Tool]:
+        return operator_instance.get_public_tools()
 
-    def test_four_public_tools(self) -> None:
-        tools = _build_operator().get_public_tools()
-        names = sorted(t.name for t in tools)
-        self.assertEqual(
-            names,
-            [
-                "appwrite_call_tool",
-                "appwrite_get_context",
-                "appwrite_search_docs",
-                "appwrite_search_tools",
-            ],
+    def _build_operator(self):
+        # Minimal ToolManager stub: the Operator's annotations are computed
+        # independently of catalog contents, so an empty ToolManager is fine.
+        from mcp_server_appwrite.tool_manager import ToolManager
+
+        return OperatorStub(tools_manager=ToolManager())
+
+    def test_appwrite_get_context_is_read(self):
+        op = self._build_operator()
+        tool = next(
+            t for t in op.get_public_tools() if t.name == "appwrite_get_context"
         )
+        ann = tool.annotations
+        assert ann is not None
+        self.assertTrue(ann.readOnlyHint)
+        self.assertFalse(ann.destructiveHint)
+        self.assertTrue(ann.idempotentHint)
+        self.assertTrue(ann.openWorldHint)
 
-    def test_each_public_tool_has_distinct_name(self) -> None:
-        tools = _build_operator().get_public_tools()
-        names = [t.name for t in tools]
-        self.assertEqual(
-            len(names),
-            len(set(names)),
-            msg=f"Duplicate tool names in public surface: {names}",
+    def test_appwrite_search_tools_is_read(self):
+        op = self._build_operator()
+        tool = next(
+            t for t in op.get_public_tools() if t.name == "appwrite_search_tools"
         )
+        ann = tool.annotations
+        assert ann is not None
+        self.assertTrue(ann.readOnlyHint)
+        self.assertFalse(ann.destructiveHint)
+        self.assertTrue(ann.idempotentHint)
+        self.assertTrue(ann.openWorldHint)
 
-
-class ToolAnnotationShapeTests(unittest.TestCase):
-    """Every public tool must declare all 4 MCP annotation hints explicitly.
-
-    Per the MCP spec, leaving a hint unset means 'unknown', which forces
-    conservative behavior in clients (they must prompt the user). We want
-    every public tool to be unambiguous so clients can make informed
-    decisions about auto-execution.
-    """
-
-    REQUIRED_HINTS = (
-        "readOnlyHint",
-        "destructiveHint",
-        "idempotentHint",
-        "openWorldHint",
-    )
-
-    def _all_public_tools(self):
-        return _build_operator().get_public_tools()
-
-    def test_every_public_tool_has_annotations(self) -> None:
-        for tool in self._all_public_tools():
-            self.assertIsNotNone(
-                tool.annotations,
-                msg=f"Tool {tool.name} has no annotations object",
-            )
-
-    def test_every_hint_is_explicit_bool(self) -> None:
-        for tool in self._all_public_tools():
-            ann = tool.annotations
-            for hint in self.REQUIRED_HINTS:
-                with self.subTest(tool=tool.name, hint=hint):
-                    value = getattr(ann, hint, None)
-                    self.assertIsInstance(
-                        value,
-                        bool,
-                        msg=(
-                            f"Tool {tool.name}.annotations.{hint} must be an "
-                            f"explicit bool, got {value!r}"
-                        ),
-                    )
-
-    def test_every_public_tool_has_human_readable_title(self) -> None:
-        for tool in self._all_public_tools():
-            ann = tool.annotations
-            self.assertTrue(
-                ann.title,
-                msg=f"Tool {tool.name}.annotations.title is empty",
-            )
-            self.assertIsInstance(ann.title, str)
-            self.assertGreaterEqual(
-                len(ann.title),
-                4,
-                msg=f"Tool {tool.name}.annotations.title too short: {ann.title!r}",
-            )
-
-
-class ToolAnnotationSemanticTests(unittest.TestCase):
-    """Cross-hint invariants that catch semantic regressions."""
-
-    def _all_public_tools(self):
-        return _build_operator().get_public_tools()
-
-    def test_readonly_implies_not_destructive(self) -> None:
-        for tool in self._all_public_tools():
-            ann = tool.annotations
-            if ann.readOnlyHint is True:
-                with self.subTest(tool=tool.name):
-                    self.assertFalse(
-                        ann.destructiveHint,
-                        msg=(
-                            f"Tool {tool.name} declares readOnlyHint=True but "
-                            f"destructiveHint={ann.destructiveHint}; "
-                            f"these are mutually exclusive"
-                        ),
-                    )
-
-    def test_readonly_implies_idempotent(self) -> None:
-        for tool in self._all_public_tools():
-            ann = tool.annotations
-            if ann.readOnlyHint is True:
-                with self.subTest(tool=tool.name):
-                    self.assertTrue(
-                        ann.idempotentHint,
-                        msg=(
-                            f"Tool {tool.name} declares readOnlyHint=True but "
-                            f"idempotentHint={ann.idempotentHint}; read-only "
-                            f"tools should be idempotent by default"
-                        ),
-                    )
-
-
-class AppwriteCallToolAnnotationTests(unittest.TestCase):
-    """appwrite_call_tool dispatches to mutating Appwrite SDK methods.
-
-    Therefore:
-    - readOnlyHint=False (it can mutate)
-    - destructiveHint=False explicit (the runtime gate is confirm_write=true,
-      not the MCP-level hint; setting it to default-True would mislead
-      clients into requiring destructive-action confirmation even for reads)
-    - idempotentHint=False (repeated calls can produce different results)
-    - openWorldHint=True (dispatches to live Appwrite APIs)
-    """
-
-    def _get_call_tool(self):
-        tools = _build_operator().get_public_tools()
-        return next(t for t in tools if t.name == "appwrite_call_tool")
-
-    def test_call_tool_is_not_readonly(self) -> None:
-        ann = self._get_call_tool().annotations
+    def test_appwrite_call_tool_is_unknown(self):
+        # The gateway tool can dispatch to write/delete tools, so it cannot
+        # honestly claim readOnlyHint=True. It must claim the conservative
+        # "unknown" bucket — readOnlyHint=False, destructiveHint=False
+        # (the runtime gate is confirm_write=true, not the hint).
+        op = self._build_operator()
+        tool = next(t for t in op.get_public_tools() if t.name == "appwrite_call_tool")
+        ann = tool.annotations
+        assert ann is not None
         self.assertFalse(ann.readOnlyHint)
-
-    def test_call_tool_destructive_hint_is_explicit_false(self) -> None:
-        ann = self._get_call_tool().annotations
-        self.assertFalse(
-            ann.destructiveHint,
-            msg=(
-                "destructiveHint=False must be explicit on appwrite_call_tool; "
-                "the runtime gate is confirm_write=true, not the MCP-level hint"
-            ),
-        )
-
-    def test_call_tool_is_not_idempotent(self) -> None:
-        ann = self._get_call_tool().annotations
+        self.assertFalse(ann.destructiveHint)
         self.assertFalse(ann.idempotentHint)
-
-    def test_call_tool_is_open_world(self) -> None:
-        ann = self._get_call_tool().annotations
         self.assertTrue(ann.openWorldHint)
 
 
-class LocalSearchToolAnnotationTests(unittest.TestCase):
-    """appwrite_search_tools and appwrite_search_docs are local index searches.
+class DocsSearchAnnotationTests(unittest.TestCase):
+    """The docs search tool carries read annotations."""
 
-    They should NOT claim openWorldHint=True — they don't make external
-    API calls for the search itself. This protects against clients
-    treating them as 'might call out to the internet' for permission
-    purposes.
+    def test_appwrite_search_docs_is_read(self):
+        # The docs index is committed; the embedder only hits OpenAI's
+        # embedding endpoint. No project writes, so the tool is read-only.
+        from pathlib import Path
+
+        ds = docs_search.DocsSearch(data_dir=Path("/nonexistent"))
+        # Force the tool definition to render even without an index loaded —
+        # `get_tool` does not depend on `_index_loaded`.
+        tool = ds.get_tool()
+        ann = tool.annotations
+        assert ann is not None
+        self.assertTrue(ann.readOnlyHint)
+        self.assertFalse(ann.destructiveHint)
+        self.assertTrue(ann.idempotentHint)
+        self.assertTrue(ann.openWorldHint)
+
+
+class DynamicSdkToolAnnotationTests(unittest.TestCase):
+    """``service.Service.list_tools`` produces annotated tools for every verb."""
+
+    def _make_service(self):
+        # Build a Service with a stub SDK that exposes one method per verb.
+        # The Service introspects via inspect.getmembers, so we need real
+        # method descriptors — plain functions don't work.
+        import appwrite.services.users as users_module
+
+        class _StubClient:
+            pass
+
+        return service.Service(users_module.Users(_StubClient()), "users")
+
+    def test_users_list_is_read(self):
+        svc = self._make_service()
+        tools = svc.list_tools()
+        list_tool = tools["users_list"]["definition"]
+        ann = list_tool.annotations
+        assert ann is not None
+        self.assertTrue(ann.readOnlyHint)
+        self.assertFalse(ann.destructiveHint)
+        self.assertTrue(ann.idempotentHint)
+        self.assertTrue(ann.openWorldHint)
+
+    def test_users_create_is_write(self):
+        svc = self._make_service()
+        tools = svc.list_tools()
+        create_tool = tools["users_create"]["definition"]
+        ann = create_tool.annotations
+        assert ann is not None
+        self.assertFalse(ann.readOnlyHint)
+        self.assertFalse(ann.destructiveHint)
+        self.assertFalse(ann.idempotentHint)
+        self.assertTrue(ann.openWorldHint)
+
+    def test_users_delete_is_delete(self):
+        svc = self._make_service()
+        tools = svc.list_tools()
+        delete_tool = tools["users_delete"]["definition"]
+        ann = delete_tool.annotations
+        assert ann is not None
+        self.assertFalse(ann.readOnlyHint)
+        self.assertTrue(ann.destructiveHint)
+        self.assertTrue(ann.idempotentHint)
+        self.assertTrue(ann.openWorldHint)
+
+    def test_all_users_tools_have_annotations(self):
+        # Catch a regression where a new SDK method gets a Tool() without
+        # annotations. Every tool returned by list_tools() must carry them.
+        svc = self._make_service()
+        tools = svc.list_tools()
+        self.assertGreater(len(tools), 5, "users service should have many tools")
+        for tool_name, entry in tools.items():
+            with self.subTest(tool=tool_name):
+                ann = entry["definition"].annotations
+                self.assertIsNotNone(
+                    ann,
+                    f"{tool_name} is missing annotations",
+                )
+                # The wire-format annotations can encode only 3 distinguishable
+                # buckets (read / delete / write-or-unknown) because MCP's
+                # spec exposes only 4 boolean hints and write + unknown share
+                # the same shape. The classification string drives the choice
+                # but the wire-format cannot always tell them apart — verify
+                # the *consistent* boundary instead of the exact bucket.
+                expected = classify_tool_name(tool_name)
+                _assert_annotations_consistent_with(ann, expected, tool_name)
+
+
+class AnnotationsModuleSurfaceTests(unittest.TestCase):
+    """The annotations module exposes the documented surface."""
+
+    def test_public_api(self):
+        self.assertTrue(hasattr(annotations, "annotations_for_classification"))
+        self.assertTrue(hasattr(annotations, "classify_tool_name"))
+        self.assertIn("annotations_for_classification", annotations.__all__)
+        self.assertIn("classify_tool_name", annotations.__all__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (used by multiple test classes)
+# ---------------------------------------------------------------------------
+
+
+def _assert_annotations_consistent_with(
+    ann: types.ToolAnnotations, bucket: str, tool_name: str
+) -> None:
+    """Verify the annotations are *consistent* with the classification bucket.
+
+    MCP's ``ToolAnnotations`` exposes only four boolean hints. With those four
+    bits we can distinguish at most three buckets on the wire:
+
+    - **read**     → readOnlyHint=True
+    - **delete**   → destructiveHint=True (with readOnlyHint=False)
+    - **write/unknown** → readOnlyHint=False, destructiveHint=False
+
+    The internal classification also distinguishes write from unknown, but
+    the wire format collapses them. We assert only what's observable: the
+    tool's readOnly/destructive pair must agree with the bucket's contract.
+    """
+    if bucket == "read":
+        assert (
+            ann.readOnlyHint is True
+        ), f"{tool_name}: read bucket must have readOnlyHint=True"
+        assert (
+            ann.destructiveHint is False
+        ), f"{tool_name}: read bucket must have destructiveHint=False"
+    elif bucket == "delete":
+        assert (
+            ann.readOnlyHint is False
+        ), f"{tool_name}: delete bucket must have readOnlyHint=False"
+        assert (
+            ann.destructiveHint is True
+        ), f"{tool_name}: delete bucket must have destructiveHint=True"
+    else:  # write or unknown — wire format is identical for both
+        assert (
+            ann.readOnlyHint is False
+        ), f"{tool_name}: {bucket} bucket must have readOnlyHint=False"
+        assert (
+            ann.destructiveHint is False
+        ), f"{tool_name}: {bucket} bucket must have destructiveHint=False"
+
+
+def _bucket_from_annotations(ann: types.ToolAnnotations) -> str:
+    """Reverse-derive the classification bucket from a ToolAnnotations instance.
+
+    Used by OperatorClassificationParityTests to confirm the Service-derived
+    annotations match the verb-bucket that ``classify_tool_name`` would
+    assign to the same tool name.
+
+    Note: the wire format cannot distinguish write from unknown (both have
+    readOnly=False, destructive=False), so this helper returns the closest
+    bucket the hints can express. Callers that need the exact bucket should
+    use ``classify_tool_name`` directly on the tool name.
+    """
+    if ann.readOnlyHint is True:
+        return "read"
+    if ann.destructiveHint is True:
+        return "delete"
+    return "write"  # write and unknown collapse here
+
+
+class OperatorStub:
+    """Minimal stand-in exposing ``get_public_tools`` for PublicToolSurfaceTests.
+
+    The Operator's annotation code path doesn't touch the catalog, so a stub
+    with an empty ToolManager is enough to exercise the public-tool annotation
+    logic without booting a real SDK client.
     """
 
-    def _search_tools(self):
-        return [t for t in _build_operator().get_public_tools() if "search" in t.name]
+    def __init__(self, tools_manager):
+        self._tools_manager = tools_manager
+        self._search_limit = 8
+        self._docs_search = None
+        # Operator requires preview_threshold + store_results too — but
+        # they're only used by execute_public_tool, not get_public_tools.
 
-    def test_two_search_tools(self) -> None:
-        tools = self._search_tools()
-        names = sorted(t.name for t in tools)
-        self.assertEqual(
-            names,
-            ["appwrite_search_docs", "appwrite_search_tools"],
-            msg=f"Expected exactly 2 search tools in public surface, got {names}",
+    def get_public_tools(self) -> list[types.Tool]:
+        # Delegate to the real Operator so we test the actual code path
+        # rather than a parallel copy.
+        from mcp_server_appwrite.operator import Operator
+
+        op = Operator(
+            tools_manager=self._tools_manager,
+            execute_tool=lambda *args, **kwargs: [],
+            docs_search=self._docs_search,
         )
-
-    def test_search_tools_are_not_open_world(self) -> None:
-        for tool in self._search_tools():
-            with self.subTest(tool=tool.name):
-                self.assertFalse(
-                    tool.annotations.openWorldHint,
-                    msg=(
-                        f"Tool {tool.name} is a local index search but "
-                        f"claims openWorldHint=True"
-                    ),
-                )
+        return op.get_public_tools()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_annotations.py
+++ b/tests/unit/test_annotations.py
@@ -12,6 +12,10 @@ test suite asserts that:
    for their semantic role.
 4. The dynamic SDK tool generator (``service.Service.list_tools``) produces
    tools with annotations matching the action verb in their name.
+5. ``annotations_for_gateway`` advertises a *gateway* profile (destructiveHint
+   unset) so MCP clients default to destructive and prompt the human user —
+   matching the ``confirm_write=true`` runtime boundary inside the server
+   (see appwrite/mcp#87 Greptile P1 review).
 
 Why this suite exists:
 
@@ -22,6 +26,11 @@ Why this suite exists:
 - The operator's `_classify_verb` (private) and the annotations module's
   `classify_tool_name` (public) must stay in lock-step; we verify they agree on
   every classification the operator uses.
+- A gateway tool that exposes a static ``destructiveHint=False`` is a security
+  hole: clients use the hint to decide whether to prompt the human user, and
+  the spec default of ``true`` (when unset) is the only safe answer for a
+  dispatcher whose outcomes depend on caller-supplied input. Pinned by the
+  Greptile review on appwrite/mcp#87.
 """
 
 from __future__ import annotations
@@ -38,6 +47,7 @@ from mcp_server_appwrite import (
 )
 from mcp_server_appwrite.annotations import (
     annotations_for_classification,
+    annotations_for_gateway,
     classify_tool_name,
 )
 
@@ -254,6 +264,76 @@ class AnnotationsForClassificationTests(unittest.TestCase):
                 )
 
 
+class AnnotationsForGatewayTests(unittest.TestCase):
+    """``annotations_for_gateway`` advertises the dispatcher profile.
+
+    A gateway cannot honestly claim a static safety profile because the
+    destructive capability depends on the sub-tool the runtime picks from
+    caller-supplied input. The helper leaves ``destructiveHint`` unset so MCP
+    clients default to destructive (the spec default) and prompt the human
+    user — matching the runtime ``confirm_write=true`` gate inside
+    ``_call_hidden_tool``.
+
+    Pinned by Greptile P1 on appwrite/mcp#87: setting
+    ``destructiveHint=False`` here would be a security hole (clients use the
+    hint to gate approval, and the hint is a model-side promise, not the
+    runtime check that ``confirm_write`` provides).
+    """
+
+    def test_destructive_hint_is_unset(self):
+        # The single most important contract: ``destructiveHint`` MUST be
+        # ``None`` so MCP clients default to ``True`` per the 2025-06-18
+        # spec and apply their host policy (typically: prompt the user).
+        # Setting ``False`` would lie about the dispatcher's capabilities
+        # and silently bypass client-side approval gates.
+        ann = annotations_for_gateway()
+        self.assertIsNone(
+            ann.destructiveHint,
+            "annotations_for_gateway().destructiveHint must be None (unset) "
+            "so clients default to destructive and prompt the user.",
+        )
+
+    def test_other_hints_are_explicit(self):
+        # readOnly/idempotent/openWorld MUST be explicit (not None) — the
+        # helper sets them to clear, defensible values without leaving the
+        # spec default to do the talking.
+        ann = annotations_for_gateway()
+        self.assertIsNotNone(ann.readOnlyHint)
+        self.assertIsNotNone(ann.idempotentHint)
+        self.assertIsNotNone(ann.openWorldHint)
+        # And the values themselves:
+        self.assertFalse(ann.readOnlyHint)
+        self.assertFalse(ann.idempotentHint)
+        self.assertTrue(ann.openWorldHint)
+
+    def test_distinct_from_unknown_bucket(self):
+        # The gateway profile MUST differ from the ``unknown`` classification:
+        # - ``unknown`` says "we cannot tell whether this is destructive" (destructive=False).
+        # - ``gateway`` says "we cannot make a static claim at all" (destructive=None).
+        # Conflating them would let a future SDK method accidentally inherit
+        # the gateway's destructive-leak-resistant behaviour, or vice-versa.
+        gateway = annotations_for_gateway()
+        unknown = annotations_for_classification("unknown")
+        self.assertIsNone(gateway.destructiveHint)
+        self.assertIsNotNone(unknown.destructiveHint)
+        self.assertFalse(unknown.destructiveHint)
+
+    def test_returns_fresh_instance_each_call(self):
+        # Each call returns a new ``ToolAnnotations`` instance so callers can
+        # mutate one without affecting later invocations (defensive — MCP
+        # tool objects sometimes accumulate client-side state).
+        a = annotations_for_gateway()
+        b = annotations_for_gateway()
+        self.assertIsNot(a, b)
+
+    def test_title_is_none(self):
+        # Consistent with the classification helpers: ``title`` is left None
+        # because the operator attaches the human-readable name from the
+        # tool's own description rather than threading a separate title.
+        ann = annotations_for_gateway()
+        self.assertIsNone(ann.title)
+
+
 class OperatorClassificationParityTests(unittest.TestCase):
     """``classify_tool_name`` and the operator's ``_classify_verb`` must agree.
 
@@ -332,17 +412,32 @@ class PublicToolSurfaceTests(unittest.TestCase):
         self.assertTrue(ann.idempotentHint)
         self.assertTrue(ann.openWorldHint)
 
-    def test_appwrite_call_tool_is_unknown(self):
-        # The gateway tool can dispatch to write/delete tools, so it cannot
-        # honestly claim readOnlyHint=True. It must claim the conservative
-        # "unknown" bucket — readOnlyHint=False, destructiveHint=False
-        # (the runtime gate is confirm_write=true, not the hint).
+    def test_appwrite_call_tool_is_gateway(self):
+        # The gateway dispatches to Appwrite SDK methods whose read/write/
+        # delete profile depends on caller-supplied input. Per the MCP
+        # 2025-06-18 spec, ``destructiveHint`` is intentionally **unset**
+        # (``None``): the spec defaults an unset hint to ``True``, which is
+        # the only honest answer for a dynamic dispatcher. Clients that gate
+        # human approval on the hint (Claude Code, Gemini MCP) will therefore
+        # prompt the user for every gateway call — matching the runtime
+        # ``confirm_write=true`` boundary in ``_call_hidden_tool``.
+        #
+        # Regression guard: a previous version of this test asserted
+        # ``destructiveHint is False``, which Greptile flagged P1 as a
+        # security hole on appwrite/mcp#87 (clients trust the hint to gate
+        # approval; setting it false advertises the gateway as non-destructive
+        # while it can dispatch delete-classified SDK calls). Do not regress.
         op = self._build_operator()
         tool = next(t for t in op.get_public_tools() if t.name == "appwrite_call_tool")
         ann = tool.annotations
         assert ann is not None
         self.assertFalse(ann.readOnlyHint)
-        self.assertFalse(ann.destructiveHint)
+        self.assertIsNone(
+            ann.destructiveHint,
+            "appwrite_call_tool.gateway.destructiveHint must be unset (None) so "
+            "MCP clients default to destructive and prompt the user; setting "
+            "False would lie about dispatch capability.",
+        )
         self.assertFalse(ann.idempotentHint)
         self.assertTrue(ann.openWorldHint)
 
@@ -442,8 +537,10 @@ class AnnotationsModuleSurfaceTests(unittest.TestCase):
 
     def test_public_api(self):
         self.assertTrue(hasattr(annotations, "annotations_for_classification"))
+        self.assertTrue(hasattr(annotations, "annotations_for_gateway"))
         self.assertTrue(hasattr(annotations, "classify_tool_name"))
         self.assertIn("annotations_for_classification", annotations.__all__)
+        self.assertIn("annotations_for_gateway", annotations.__all__)
         self.assertIn("classify_tool_name", annotations.__all__)
 
 


### PR DESCRIPTION
## Rebase onto MCP Python SDK v2 (#89)

Rebased this PR onto `f37d118` (PR #89 by @ChiragAgg5k, "Migrate to MCP Python SDK v2", merged 2026-07-29). The SDK migration is orthogonal to the safety annotations work:

- `types.Tool.annotations` is stable across MCP Python SDK v1 and v2.
- `upstream/main` at `f37d118` contains zero references to `ToolAnnotations` (`git grep -nE 'ToolAnnotations|annotations_for' upstream/main` returns 0 matches). PR #87 remains the only PR introducing centralised ToolAnnotations.
- The migration's snake_case field aliases (`input_schema`, `output_schema`) on `Tool` apply to the schema structure, not to the `annotations` field. No collision.

The rebase produced two file conflicts:

- `src/mcp_server_appwrite/docs_search.py`: accepted `--theirs` (snake_case `input_schema` from #89; the annotations call was reapplied on top).
- `src/mcp_server_appwrite/operator.py`: manual merge preserving both #89's import-block changes and the centralised annotations imports plus the `annotations_for_classification` / `annotations_for_gateway` calls.

## Note on intervening PRs (#90, #91, #92)

Three PRs merged after #89 and touch files in this PR's scope:

- **#90** "surface parameter schemas in appwrite_search_tools results" modifies `docs_search.py` and `operator.py`. The `annotations=read_annotations` on `appwrite_search_tools` stayed intact; only the schema-surfacing side of that tool's definition changed.
- **#91** "Adopt the console Python SDK for control-plane tools" is a large refactor of `operator.py`, `service.py`, and `server.py`. The `from .annotations import annotations_for_classification, annotations_for_gateway` import and the annotated `Tool()` calls remain compatible with the refactored structure.
- **#92** "Fix project usage parsing with Console SDK 0.3" depends on #91 and has no overlap with this PR's files.

Rebased onto `f37d118` (the SDK v2 migration). When this PR is reviewed and merged, please rebase onto the current `main` so the diff against upstream reflects only PR #87's additions.

## Design evolution vs the original proposal in #86

The original proposal in #86 suggested `destructiveHint=False` for `appwrite_call_tool`. During review, Greptile Bot flagged that this contradicts the MCP 2025-06-18 spec default semantics: setting the hint explicitly to `False` signals "definitely safe", which is wrong for a dispatcher whose inner behaviour depends on the target tool.

This PR resolves it with `annotations_for_gateway()`, a dedicated helper that returns `ToolAnnotations(destructiveHint=None, ...)`. Per the MCP 2025-06-18 spec, an unset `destructiveHint` defaults to `True` on the client side, which is the honest semantics for a gateway. Clients that gate human approval on the hint correctly prompt the user for every gateway call, while `confirm_write=true` stays as the per-call inner gate for Appwrite's destructive SDK calls. The two layers cooperate; neither is a workaround for the other.

## On benchmarks

A separate `test/mcp-benchmarks` branch holds an earlier `tests/unit/test_benchmarks.py` draft. It was deliberately not included in this PR for three concrete reasons:

1. Time-based assertions are flaky on CI (e.g. `assert elapsed < 0.25` for `_clamp_limit`). CI runners are routinely 2 to 5x slower than developer machines, so the assertion becomes a coin flip.
2. One assertion contradicts this PR's design. It asserts `tool.annotations.title == "Appwrite Documentation Search"`, but `annotations_for_classification` returns `ToolAnnotations(title=None, ...)`. The test would fail against the current implementation.
3. `Operator(manager, executor, docs_search=...)` is not callable. The rebased `Operator.__init__` types `execute_tool` as `Callable[...]`. `ThreadPoolExecutor` is not directly callable (it has `submit()`); the runtime throws `TypeError` when Operator tries to dispatch.

If reviewers want deterministic performance signals, the right vehicle is a separate PR using `pytest-benchmark` (with warmup, multi-iteration statistics, and stddev reporting), not assertions on raw wall-clock elapsed.

## Local validation on the rebased tip

- `python -m unittest discover -s tests/unit` passes on mcp 2.0.0 (the version PR #89's migration requires). Local environments with mcp 1.27.2 hit a Pydantic `ValidationError` on `input_schema=` because the field name in 1.x was `inputSchema` (camelCase). Upstream CI runs mcp 2.0.0 and is green.
- `ruff check src tests`, `black --check src tests`, `pyright` all pass.

## Effective diff

`git diff upstream/main...HEAD` (at `f37d118`):

```
 src/mcp_server_appwrite/annotations.py | 236 ++++++++++++
 src/mcp_server_appwrite/docs_search.py |   8 +
 src/mcp_server_appwrite/operator.py    |  27 ++
 src/mcp_server_appwrite/service.py     |   8 +
 tests/unit/test_annotations.py         | 639 +++++++++++++++++++++
 5 files changed, 918 insertions(+)
```
