### PR TITLE
Fix project usage parsing with Console SDK 0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "anyio>=4.0.0",
-    "appwrite-console>=0.2.1,<0.3",
+    "appwrite-console>=0.3.0,<0.4",
     "docstring-parser>=0.16",
     "mcp[cli]>=2,<3",
     "python-dotenv>=1.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -39,15 +39,15 @@ wheels = [
 
 [[package]]
 name = "appwrite-console"
-version = "0.2.1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/b2/36866a4356930ea66cd9209060a43a7a4b775840788c493fa76ff6e4e7fd/appwrite_console-0.2.1.tar.gz", hash = "sha256:a3892c0e94ed211260f404646f7b82f9d8ae596a4a428590be63bc9fff476585", size = 293961, upload-time = "2026-08-03T17:01:20.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/2e/225524a64d849dffc1580c65efa1f2797962a9018c18c6332cbf65ebaa38/appwrite_console-0.3.0.tar.gz", hash = "sha256:8065c9e29fe4d8c75e565a9e14b94e1822f080afe408380c50adf5fa4d50955f", size = 294701, upload-time = "2026-08-04T11:58:52.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/16/70b34ba7fe38a158c9d9879d88118f1dcf9ba900c70d58b1a9587c82ca76/appwrite_console-0.2.1-py3-none-any.whl", hash = "sha256:6aa4f5d32eadf0ecf3c98b2ef78b628443c8f01f58bc7e0855263c8af82a5b86", size = 515596, upload-time = "2026-08-03T17:01:18.886Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/7d144e6cf5c877b57b26da230af9f771695ebd229f6b096ece567084bd52/appwrite_console-0.3.0-py3-none-any.whl", hash = "sha256:83497d711ac0aa8e30b67b62c9423b216ee7a20ddc4b1202b8656bf1f0bd1f21", size = 517531, upload-time = "2026-08-04T11:58:51.097Z" },
 ]
 
 [[package]]
@@ -695,7 +695,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0.0" },
-    { name = "appwrite-console", specifier = ">=0.2.1,<0.3" },
+    { name = "appwrite-console", specifier = ">=0.3.0,<0.4" },
     { name = "argon2-cffi", marker = "extra == 'integration'", specifier = ">=23.1.0" },
     { name = "bcrypt", marker = "extra == 'integration'", specifier = ">=4.1.2" },
     { name = "docstring-parser", specifier = ">=0.16" },


### PR DESCRIPTION
## Summary

- upgrade `appwrite-console` from the `0.2.x` line to `0.3.x`
- refresh the lockfile to resolve `appwrite-console==0.3.0`
- fix `project_get_usage` response parsing for text embedding metrics

## Testing

- `uv run --group dev ruff check src tests`
- `uv run --group dev black --check src tests`
- `uv run --group dev pyright`
- `uv run python -m unittest discover -s tests/unit -v` (200 tests)
- validated `UsageProject` with embedding metric arrays and numeric totals

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issue

#XXXX
