### PR TITLE
fix: raise inline upload limit to 10MB

### DIFF
--- a/src/mcp_server_appwrite/constants.py
+++ b/src/mcp_server_appwrite/constants.py
@@ -49,7 +49,9 @@ VALIDATION_SERVICE_ORDER = (
 EXCLUDED_SERVICES: frozenset[str] = frozenset()
 
 MAX_FETCH_BYTES = 25 * 1024 * 1024  # 25 MB cap on server-fetched files
-MAX_INLINE_BYTES = 256 * 1024  # 256 KB cap on decoded inline content
+# Match Cloud/agent chat attachment max (10 MB). Hosted uploads resolve
+# turn attachments to inline base64; keep this at least that large.
+MAX_INLINE_BYTES = 10 * 1024 * 1024  # 10 MB cap on decoded inline content
 FETCH_TIMEOUT_SECONDS = 30.0
 FETCH_MAX_REDIRECTS = 5
 


### PR DESCRIPTION
## Summary
- Raise `MAX_INLINE_BYTES` from 256KB to 10MB so hosted MCP can accept chat attachment bytes rewritten as inline base64 by the agent
- Aligns with Cloud/agent chat attachment max (10MB)

Companion: https://github.com/appwrite/agent/pull/1

## Test plan
- [ ] Upload a ~500KB–2MB file via hosted MCP with `{filename, content, encoding: base64}`
- [ ] Confirm files under 10MB succeed and over 10MB still fail with the size error