### PR TITLE
fix: address MCP benchmark findings on schema quality and round-trips

### DIFF
--- a/src/mcp_server_appwrite/constants.py
+++ b/src/mcp_server_appwrite/constants.py
@@ -90,7 +90,9 @@ CORS_HEADERS = {
 # --- operator -------------------------------------------------------------
 
 SEARCH_LIMIT = 8
-PREVIEW_THRESHOLD = 800
+# A page of rows does not fit in 800 characters, so the model paid a
+# resources/read for every list call. Only stdio stores results at all.
+PREVIEW_THRESHOLD = 4000
 RESULT_STORE_SIZE = 50
 CATALOG_URI = "appwrite://operator/catalog"
 RESULT_URI_TEMPLATE = "appwrite://operator/results/{result_id}"

--- a/src/mcp_server_appwrite/error_classification.py
+++ b/src/mcp_server_appwrite/error_classification.py
@@ -76,6 +76,15 @@ def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
             pending.append(current.__cause__)
 
 
+def is_response_parse_error(exc: BaseException) -> bool:
+    """Whether ``exc`` is the SDK failing to deserialize an Appwrite response.
+
+    The request itself reached Appwrite and was accepted, so the caller must not
+    present this as a failed operation (see ``_format_appwrite_error``).
+    """
+    return any(_is_sdk_validation_error(item) for item in _exception_chain(exc))
+
+
 def _is_sdk_validation_error(exc: BaseException) -> bool:
     error_type = type(exc)
     if error_type.__name__ == "ValidationError" and error_type.__module__.startswith(

--- a/src/mcp_server_appwrite/operator.py
+++ b/src/mcp_server_appwrite/operator.py
@@ -6,6 +6,7 @@ import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
+from difflib import get_close_matches
 from typing import Any, Callable
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -404,13 +405,17 @@ class Operator:
         return entries
 
     def _catalog_json(self) -> str:
+        # Parameter names and shapes are included (descriptions are not, to keep
+        # the resource small) so a client can read the catalog once instead of
+        # paying a search call per tool it already knows it wants.
         return json.dumps(
             [
                 {
                     "action_verb": entry.action_verb,
                     "classification": entry.classification,
                     "context_scope": entry.context_scope,
-                    "description": entry.description,
+                    "description": entry.description[:_CATALOG_DESCRIPTION_LIMIT],
+                    "parameters": _catalog_parameters(entry),
                     "required": entry.required,
                     "resource_name": entry.resource_name,
                     "service_name": entry.service_name,
@@ -457,7 +462,7 @@ class Operator:
                     else ""
                 )
                 description = (
-                    f"\n   {match.entry.description[:140]}"
+                    f"\n   {match.entry.description[:_TOOL_DESCRIPTION_LIMIT]}"
                     if match.entry.description
                     else ""
                 )
@@ -484,9 +489,17 @@ class Operator:
         entry = self._catalog_map.get(tool_name)
         if not entry:
             telemetry.record_hallucination(tool_name)
-            raise ValueError(
-                f"Tool {tool_name} was not found. Use appwrite_search_tools first."
+            # Naming the near misses saves the search round trip a near-miss guess
+            # would otherwise cost.
+            suggestions = get_close_matches(
+                tool_name, self._catalog_map, n=_SUGGESTION_LIMIT, cutoff=0.6
             )
+            hint = (
+                f" Closest matches: {', '.join(suggestions)}."
+                if suggestions
+                else " Use appwrite_search_tools to find the right tool."
+            )
+            raise ValueError(f"Tool {tool_name} was not found.{hint}")
 
         confirm_write = bool(
             raw_arguments.get("confirm_write", raw_arguments.get("confirmWrite", False))
@@ -586,6 +599,10 @@ class Operator:
             score = _compute_score(
                 entry, query_tokens, query_lower, service_hint_set, missing_required
             )
+            # Relevance is gated by whether the query names the entry at all
+            # (see _compute_score), not by a score threshold: an inflection is a
+            # weaker signal than an exact token but still a real match, and a
+            # numeric floor on top of the gate only discards those.
             if score <= 0:
                 continue
             ranked.append(
@@ -598,6 +615,13 @@ class Operator:
         return ranked[:limit]
 
 
+_MIN_INFLECTION_TOKEN_LENGTH = 3
+_MAX_INFLECTION_SUFFIX = 2
+_SUGGESTION_LIMIT = 5
+# A read whose query names neither "get" nor "list".
+AMBIGUOUS_READ_INTENT = "read"
+
+
 def _normalize_token(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
 
@@ -606,6 +630,29 @@ def _tokenize(value: str) -> list[str]:
     normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", value)
     tokens = re.split(r"[^a-zA-Z0-9]+", normalized.lower())
     return list(dict.fromkeys(token for token in tokens if len(token) >= 2))
+
+
+def _is_inflection(first: str, second: str) -> bool:
+    """Whether two tokens differ only by a common inflection.
+
+    Searching "row" must still find ``list_rows``, and "policy" must find
+    ``policies``. Plain containment is too loose to carry that — it also matches
+    "id" against "identity" and pulled unrelated services into every result — so
+    require a shared stem and a short difference in length instead.
+    """
+    shorter, longer = sorted((first, second), key=len)
+    if len(shorter) < _MIN_INFLECTION_TOKEN_LENGTH:
+        return False
+    if len(longer) - len(shorter) > _MAX_INFLECTION_SUFFIX:
+        return False
+
+    shared = 0
+    for shorter_char, longer_char in zip(shorter, longer):
+        if shorter_char != longer_char:
+            break
+        shared += 1
+
+    return shared >= _MIN_INFLECTION_TOKEN_LENGTH and shared >= len(shorter) - 2
 
 
 def _classify_verb(action_verb: str) -> str:
@@ -653,26 +700,72 @@ def _has_schema_property(entry: CatalogEntry, key: str) -> bool:
     return isinstance(properties, dict) and key in properties
 
 
-_PARAM_DESCRIPTION_LIMIT = 120
+_PARAM_DESCRIPTION_LIMIT = 600
+_TOOL_DESCRIPTION_LIMIT = 400
+_CATALOG_DESCRIPTION_LIMIT = 200
 
 
 def _json_schema_type_label(schema: dict[str, Any] | Any) -> str:
+    """Render a parameter's accepted shape.
+
+    Search output is the only channel through which the model sees a hidden
+    tool's schema, so enum members and union branches must survive: labelling a
+    ``oneOf[string, object]`` upload parameter as ``string`` makes the object
+    form undiscoverable, and dropping enum members leaves values unguessable.
+    """
     if not isinstance(schema, dict):
         return "string"
+
+    branches = schema.get("oneOf") or schema.get("anyOf")
+    if isinstance(branches, list) and branches:
+        labels = list(
+            dict.fromkeys(_json_schema_type_label(branch) for branch in branches)
+        )
+        return "|".join(labels)
 
     schema_type = schema.get("type")
     if schema_type == "array":
         items = schema.get("items")
         if isinstance(items, dict):
-            item_type = items.get("type")
-            if isinstance(item_type, str) and item_type:
-                return f"array[{item_type}]"
+            return f"array[{_json_schema_type_label(items)}]"
         return "array"
 
-    if isinstance(schema_type, str) and schema_type:
-        return schema_type
+    label = schema_type if isinstance(schema_type, str) and schema_type else "string"
 
-    return "string"
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and enum_values:
+        members = "|".join(str(value) for value in enum_values)
+        return f"{label} enum[{members}]"
+
+    return label
+
+
+def _catalog_parameters(entry: CatalogEntry) -> dict[str, str]:
+    properties = entry.input_schema.get("properties")
+    if not isinstance(properties, dict):
+        return {}
+    return {
+        name: _json_schema_type_label(schema) for name, schema in properties.items()
+    }
+
+
+def _object_keys_hint(schema: dict[str, Any] | Any) -> str:
+    """Names of the properties an object parameter (or object branch) accepts."""
+    if not isinstance(schema, dict):
+        return ""
+
+    keys: list[str] = []
+    candidates = [schema]
+    branches = schema.get("oneOf") or schema.get("anyOf")
+    if isinstance(branches, list):
+        candidates.extend(branch for branch in branches if isinstance(branch, dict))
+
+    for candidate in candidates:
+        properties = candidate.get("properties")
+        if isinstance(properties, dict):
+            keys.extend(key for key in properties if key not in keys)
+
+    return ", ".join(keys)
 
 
 def _format_params_block(entry: CatalogEntry) -> str:
@@ -700,6 +793,10 @@ def _format_params_block(entry: CatalogEntry) -> str:
         else:
             lines.append(f"     - {name} ({type_label}, {requirement})")
 
+        object_keys = _object_keys_hint(prop_schema)
+        if object_keys:
+            lines.append(f"       object keys: {object_keys}")
+
     return "\n".join(lines)
 
 
@@ -724,26 +821,35 @@ def _compute_score(
     )
 
     score = 0
-    needs_substring = False
+    matches = 0
     for query_token in query_tokens:
         if query_token in haystack_tokens:
+            matches += 1
             score += 5
-        else:
-            needs_substring = True
+        elif any(
+            _is_inflection(query_token, haystack_token)
+            for haystack_token in haystack_tokens
+        ):
+            matches += 1
+            score += 3
 
-    if needs_substring:
-        for query_token in query_tokens:
-            if query_token not in haystack_tokens and any(
-                haystack_token in query_token or query_token in haystack_token
-                for haystack_token in haystack_tokens
-            ):
-                score += 3
+    names_this_tool = entry.tool_name.lower() in query_lower
+    hinted_service = bool(
+        service_hints and _normalize_token(entry.service_name) in service_hints
+    )
+    # An entry nothing in the query actually names is noise, however much
+    # generic credit the heuristics below would award it.
+    if not matches and not hinted_service and not names_this_tool:
+        return 0
 
-    if service_hints and _normalize_token(entry.service_name) in service_hints:
+    if hinted_service:
         score += 8
 
     query_intent = _infer_query_intent(query_tokens)
-    if query_intent == entry.action_verb:
+    if query_intent == AMBIGUOUS_READ_INTENT:
+        # Let the resource tokens decide between get and list.
+        score += 6 if entry.classification == "read" else -5
+    elif query_intent == entry.action_verb:
         score += 12
     elif query_intent:
         if query_intent in READ_VERBS and entry.classification != "read":
@@ -759,13 +865,20 @@ def _compute_score(
     elif entry.required:
         score += 3
 
-    if entry.tool_name.lower() in query_lower:
+    if names_this_tool:
         score += 10
 
     return score
 
 
 def _infer_query_intent(query_tokens: list[str]) -> str | None:
+    """Infer the action the query is asking for.
+
+    ``AMBIGUOUS_READ_INTENT`` means "a read, but get or list is undecided" —
+    words like "read" or "fetch" name neither. Collapsing them onto ``get``
+    scored every single-item tool above every list tool, so "read rows with
+    pagination" returned eight get-one-row tools and no list tool at all.
+    """
     token_set = set(query_tokens)
     if token_set & CREATE_HINTS:
         return "create"
@@ -775,8 +888,10 @@ def _infer_query_intent(query_tokens: list[str]) -> str | None:
         return "delete"
     if token_set & {"list"}:
         return "list"
-    if token_set & READ_HINTS:
+    if token_set & {"get"}:
         return "get"
+    if token_set & READ_HINTS:
+        return AMBIGUOUS_READ_INTENT
     return None
 
 
@@ -785,7 +900,7 @@ def _resolve_include_mutating(value: Any, query: str) -> bool:
         return bool(value)
 
     query_intent = _infer_query_intent(_tokenize(query))
-    return query_intent not in {None, "list", "get"}
+    return query_intent not in {None, "list", "get", AMBIGUOUS_READ_INTENT}
 
 
 def _normalize_string_list(value: Any) -> list[str] | None:

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -72,6 +72,7 @@ from .context import (
     get_appwrite_context,
 )
 from .docs_search import DocsSearch
+from .error_classification import is_response_parse_error
 from .operator import Operator, _parse_tool_name
 from .service import Service
 from .tool_manager import ToolManager
@@ -857,7 +858,7 @@ def execute_registered_tool(
             project_id=target_project,
             organization_id=organization_id,
         )
-        raise RuntimeError(_format_appwrite_error(exc)) from exc
+        raise RuntimeError(_format_appwrite_error(exc, tool_name=name)) from exc
     except Exception as exc:
         error_monitoring.capture_exception(
             exc,
@@ -973,7 +974,10 @@ def _format_tool_result(
     return [types.TextContent(type="text", text=str(result))]
 
 
-def _format_appwrite_error(exc: AppwriteException) -> str:
+def _format_appwrite_error(exc: AppwriteException, tool_name: str | None = None) -> str:
+    if is_response_parse_error(exc):
+        return _format_response_parse_error(tool_name)
+
     details = []
     if getattr(exc, "code", None):
         details.append(f"code={exc.code}")
@@ -984,6 +988,26 @@ def _format_appwrite_error(exc: AppwriteException) -> str:
     if len(message) > 500:
         message = f"{message[:500]}..."
     return f"Appwrite request failed{detail_text}: {message}"
+
+
+def _format_response_parse_error(tool_name: str | None) -> str:
+    """Explain an SDK deserialization failure without implying the write failed.
+
+    ``Service._parse_response`` raises this after Appwrite has already accepted
+    the request, and it discards the response body, so the operation usually
+    succeeded. Reporting the raw Pydantic error invites the model to retry a
+    completed mutation.
+    """
+    verify = (
+        f" Verify with the matching get or list tool for {tool_name} before retrying."
+        if tool_name
+        else " Verify with the matching get or list tool before retrying."
+    )
+    return (
+        "Appwrite accepted the request, but the SDK could not deserialize the "
+        "response, so the result is unavailable. The operation most likely "
+        f"succeeded — do not retry it blindly.{verify}"
+    )
 
 
 def build_instructions(transport: str = "http") -> str:

--- a/tests/unit/test_error_classification.py
+++ b/tests/unit/test_error_classification.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ValidationError
 from mcp_server_appwrite.error_classification import (
     WriteConfirmationRequired,
     classify_tool_error,
+    is_response_parse_error,
 )
 
 
@@ -71,6 +72,17 @@ class ErrorClassificationTests(unittest.TestCase):
         second.__context__ = first
 
         self.assertEqual(classify_tool_error(first), "appwrite_4xx")
+
+    def test_recognizes_response_parse_errors_through_the_chain(self):
+        parse_failure = AppwriteException("Unable to parse response into Project: ...")
+        wrapped = RuntimeError("wrapped")
+        wrapped.__cause__ = parse_failure
+
+        self.assertTrue(is_response_parse_error(parse_failure))
+        self.assertTrue(is_response_parse_error(wrapped))
+        self.assertFalse(
+            is_response_parse_error(AppwriteException("not found", 404, "not_found"))
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -3,9 +3,14 @@ from concurrent.futures import ThreadPoolExecutor
 
 import mcp.types as types
 
+from mcp_server_appwrite.constants import PREVIEW_THRESHOLD
 from mcp_server_appwrite.error_classification import WriteConfirmationRequired
 from mcp_server_appwrite.operator import CATALOG_URI, Operator, ResultStore
 from mcp_server_appwrite.tool_manager import ToolManager
+
+# Tracks the threshold rather than hardcoding a size, so tuning the threshold
+# does not silently turn these into same-shape tests of the inline path.
+OVERSIZED_TEXT = "x" * (PREVIEW_THRESHOLD + 100)
 
 
 def make_tool(
@@ -210,7 +215,7 @@ class OperatorTests(unittest.TestCase):
         self.assertEqual(result[0].text, '{"results": []}')
 
     def test_docs_tool_large_result_is_stored_as_resource(self):
-        docs = FakeDocsSearch([types.TextContent(type="text", text="x" * 1200)])
+        docs = FakeDocsSearch([types.TextContent(type="text", text=OVERSIZED_TEXT)])
         runtime = self.make_runtime_with_docs(docs)
 
         result = runtime.execute_public_tool(
@@ -231,6 +236,203 @@ class OperatorTests(unittest.TestCase):
         self.assertIn("tables_db_list", result[0].text)
         self.assertIn("context=console", result[0].text)
         self.assertIn(CATALOG_URI, result[0].text)
+
+    def test_search_output_renders_enum_members(self):
+        manager = ToolManager()
+        manager.tools_registry = {
+            "tables_db_create_relationship_column": {
+                "definition": make_tool(
+                    "tables_db_create_relationship_column",
+                    "Create relationship column.",
+                    ["type"],
+                    properties={
+                        "type": {
+                            "type": "string",
+                            "enum": ["oneToOne", "oneToMany"],
+                            "description": "Relation type",
+                        },
+                    },
+                ),
+            }
+        }
+        runtime = Operator(manager, lambda *_: [])
+
+        result = runtime.execute_public_tool(
+            "appwrite_search_tools",
+            {"query": "create relationship column", "include_mutating": True},
+        )
+
+        # Search output is the only channel carrying a hidden tool's schema, so
+        # unguessable values must survive rendering.
+        self.assertIn("string enum[oneToOne|oneToMany]", result[0].text)
+
+    def test_search_output_renders_union_and_object_keys(self):
+        manager = ToolManager()
+        manager.tools_registry = {
+            "storage_create_file": {
+                "definition": make_tool(
+                    "storage_create_file",
+                    "Create a file.",
+                    ["file"],
+                    properties={
+                        "file": {
+                            "oneOf": [
+                                {"type": "string"},
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {"type": "string"},
+                                        "filename": {"type": "string"},
+                                    },
+                                },
+                            ],
+                            "description": "Binary file.",
+                        },
+                    },
+                ),
+            }
+        }
+        runtime = Operator(manager, lambda *_: [])
+
+        result = runtime.execute_public_tool(
+            "appwrite_search_tools",
+            {"query": "create file", "include_mutating": True},
+        )
+
+        self.assertIn("file (string|object, required)", result[0].text)
+        self.assertIn("object keys: url, filename", result[0].text)
+
+    def test_search_drops_entries_sharing_no_query_token(self):
+        manager = ToolManager()
+        manager.tools_registry = {
+            "tables_db_list": {
+                "definition": make_tool("tables_db_list", "List all databases."),
+            },
+            "avatars_get_favicon": {
+                "definition": make_tool("avatars_get_favicon", "Get a favicon."),
+            },
+        }
+        runtime = Operator(manager, lambda *_: [])
+
+        result = runtime.execute_public_tool(
+            "appwrite_search_tools", {"query": "list databases"}
+        )
+
+        # An entry nothing in the query names is noise the model still has to
+        # read and discard; loose substring overlap used to keep it in.
+        self.assertIn("tables_db_list", result[0].text)
+        self.assertNotIn("avatars_get_favicon", result[0].text)
+
+    def test_search_matches_across_singular_and_plural(self):
+        manager = ToolManager()
+        manager.tools_registry = {
+            "tables_db_list_rows": {
+                "definition": make_tool("tables_db_list_rows", "List rows."),
+            },
+            "tables_db_get_row": {
+                "definition": make_tool("tables_db_get_row", "Get a row."),
+            },
+            "avatars_get_favicon": {
+                "definition": make_tool("avatars_get_favicon", "Get a favicon."),
+            },
+        }
+        runtime = Operator(manager, lambda *_: [])
+
+        for query in ("row", "rows"):
+            result = runtime.execute_public_tool(
+                "appwrite_search_tools", {"query": query}
+            )
+            # An inflection is a real match; requiring an exact token hid the
+            # sibling tool entirely (searching "row" lost list_rows).
+            self.assertIn("tables_db_list_rows", result[0].text, query)
+            self.assertIn("tables_db_get_row", result[0].text, query)
+            self.assertNotIn("avatars_get_favicon", result[0].text, query)
+
+    def test_inflection_alone_is_enough_to_be_returned(self):
+        manager = ToolManager()
+        manager.tools_registry = {
+            # No required params and a mutating verb, so the inflection match is
+            # this entry's only source of score — the case a numeric relevance
+            # floor on top of the match gate would silently discard.
+            "tables_db_create_rows": {
+                "definition": make_tool("tables_db_create_rows", "Create new rows."),
+            },
+        }
+        runtime = Operator(manager, lambda *_: [])
+
+        result = runtime.execute_public_tool(
+            "appwrite_search_tools", {"query": "row", "include_mutating": True}
+        )
+
+        self.assertIn("tables_db_create_rows", result[0].text)
+
+    def test_search_ranks_the_named_service_first(self):
+        runtime = self.make_runtime(lambda name, arguments, *_: [])
+
+        result = runtime.execute_public_tool(
+            "appwrite_search_tools", {"query": "list databases"}
+        )
+
+        # Sibling list tools still match on the verb, but rank below the service
+        # the query actually names, and a verb mismatch drops out entirely.
+        self.assertLess(
+            result[0].text.index("tables_db_list"), result[0].text.index("users_list")
+        )
+        self.assertNotIn("functions_get", result[0].text)
+
+    def test_ambiguous_read_verb_does_not_bury_list_tools(self):
+        runtime = self.make_runtime(lambda name, arguments, *_: [])
+
+        result = runtime.execute_public_tool(
+            "appwrite_search_tools", {"query": "read all databases"}
+        )
+
+        # "read" names neither get nor list; collapsing it onto get scored every
+        # single-item tool above every list tool, so the list tool fell off the
+        # page entirely. Resource tokens should decide instead.
+        self.assertIn("tables_db_list", result[0].text)
+        self.assertLess(
+            result[0].text.index("tables_db_list"), result[0].text.index("users_list")
+        )
+
+    def test_ambiguous_read_verb_still_excludes_mutating_tools(self):
+        runtime = self.make_runtime(lambda name, arguments, *_: [])
+
+        result = runtime.execute_public_tool(
+            "appwrite_search_tools", {"query": "read all databases"}
+        )
+
+        self.assertNotIn("tables_db_create", result[0].text)
+
+    def test_unknown_tool_names_the_closest_matches(self):
+        runtime = self.make_runtime(lambda name, arguments, *_: [])
+
+        with self.assertRaises(ValueError) as caught:
+            runtime.execute_public_tool(
+                "appwrite_call_tool", {"tool_name": "tables_db_lst"}
+            )
+
+        # Naming near misses saves the search round trip a typo would cost.
+        self.assertIn("tables_db_list", str(caught.exception))
+
+    def test_unknown_tool_without_near_misses_points_at_search(self):
+        runtime = self.make_runtime(lambda name, arguments, *_: [])
+
+        with self.assertRaises(ValueError) as caught:
+            runtime.execute_public_tool(
+                "appwrite_call_tool", {"tool_name": "wholly_unrelated"}
+            )
+
+        self.assertIn("appwrite_search_tools", str(caught.exception))
+
+    def test_catalog_carries_parameter_shapes(self):
+        runtime = self.make_runtime(lambda name, arguments, *_: [])
+
+        catalog = runtime.read_resource(CATALOG_URI)[0].content
+
+        # Lets a client read the catalog once instead of searching per tool.
+        self.assertIn('"parameters"', catalog)
+        self.assertIn('"size": "number"', catalog)
 
     def test_catalog_and_search_surface_target_context(self):
         manager = ToolManager()
@@ -429,7 +631,7 @@ class OperatorTests(unittest.TestCase):
     def test_large_result_is_stored_as_resource(self):
         runtime = self.make_runtime(
             lambda name, arguments, *_: [
-                types.TextContent(type="text", text="x" * 1200)
+                types.TextContent(type="text", text=OVERSIZED_TEXT)
             ]
         )
 
@@ -463,7 +665,7 @@ class OperatorTests(unittest.TestCase):
         runtime = Operator(
             manager,
             lambda name, arguments, *_: [
-                types.TextContent(type="text", text="x" * 1200)
+                types.TextContent(type="text", text=OVERSIZED_TEXT)
             ],
             store_results=False,
         )
@@ -473,7 +675,7 @@ class OperatorTests(unittest.TestCase):
             {"tool_name": "tables_db_list"},
         )
 
-        self.assertEqual(result[0].text, "x" * 1200)
+        self.assertEqual(result[0].text, OVERSIZED_TEXT)
         self.assertNotIn("appwrite://operator/results/", result[0].text)
 
     def test_store_results_false_returns_image_inline(self):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -427,6 +427,18 @@ class ServerHelperTests(unittest.TestCase):
         self.assertLess(len(message), 560)
         self.assertTrue(message.endswith("..."))
 
+    def test_format_appwrite_error_does_not_report_parse_failure_as_failure(self):
+        exc = AppwriteException(
+            "Unable to parse response into Project: 1 validation error for Project"
+        )
+
+        message = _format_appwrite_error(exc, tool_name="projects_create")
+
+        self.assertIn("accepted the request", message)
+        self.assertIn("most likely", message)
+        self.assertIn("projects_create", message)
+        self.assertNotIn("validation error", message)
+
     def test_mcp_request_context_extracts_client_metadata(self):
         ctx = Mock()
         ctx.protocol_version = "2025-06-18"


### PR DESCRIPTION
Acts on the [Appwrite MCP vs Supabase MCP benchmark](https://6a79b8b74e1f6bf83f68.appwrite.network/), which scored us 2/5 on schema quality and 2/5 on round-trips per task. Every claim in the report was reproduced against the code before being acted on; three turned out to be misattributed and one understated.

**Scope:** this PR contains only defects that are genuinely ours. Anything whose root cause is in the Python SDK or the Appwrite API is triaged, not worked around here — several are bugs affecting every SDK consumer, and papering over them in one client would hide the defect while leaving everyone else broken. See the triage notes shared separately (9 items, 2 High).

That means the benchmark's T7 (paginated read) and T6 (bulk insert) costs stand until the upstream fixes land. Called out explicitly below.

Every before/after pair here was measured against the real 981-tool catalog, with "before" captured by running the original code from a temporary worktree at `main`.

---

## 1. Enum values and object shapes were invisible to the model

`appwrite_search_tools` output is the only channel through which the model ever sees a hidden tool's parameter schema — the catalog resource omitted `input_schema`, and hidden tools are never listed via `tools/list`. So whatever the renderer dropped did not exist to the client.

Both values were already correct in the generated schema and thrown away at render time by `_json_schema_type_label`, which ignored `enum` and returned the literal `"string"` for any `oneOf`.

**Before**

```
tables_db_create_relationship_column
  - type (string, required): Relation type
  - on_delete (string, optional): Constraints option
storage_create_file
  - file (string, required): Binary file. Appwrite SDKs provide helpers to handle file input. […]
```

**After**

```
tables_db_create_relationship_column
  - type (string enum[oneToOne|manyToOne|manyToMany|oneToMany], required): Relation type
  - on_delete (string enum[cascade|restrict|setNull], optional): Constraints option
storage_create_file
  - file (string|object, required): Binary file. Appwrite SDKs provide helpers to handle file input. […]
    object keys: url, path, filename, content, encoding, mime_type
```

Covers the report's "missing enum documentation for relationship `type` and `on_delete`" and "file parameter typed as string but requires object structure". Note both were *our* rendering bug — the spec descriptions are separately weak, which is triaged.

## 2. Descriptions truncated mid-word

`_PARAM_DESCRIPTION_LIMIT = 120` cut the structural contracts exactly where the useful part starts, which is a large part of why the report could not determine the query format or the column type token.

**Before**

```
- queries (array[string], optional): Array of query strings generated using the Query class provided by the SDK. [Learn more about queri
- columns (array[object], optional): … type (string: string, integer, float, b
```

**After** — limits raised to 600 (params) and 400 (tool descriptions); the full text now survives

```
- queries (array[string], optional): Array of query strings generated using the Query class
  provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum
  of 100 queries are allowed, each 4096 characters long.
```

The remaining problem — that this text describes an SDK helper class an MCP client does not have, and never states the wire format — is a spec defect, triaged as item 6.

## 3. Search returned pages of unrelated tools

Containment in either direction with no minimum score meant short tokens matched almost everything. Measured on the real catalog:

```
# Before
'paginated read of rows'    -> oauth2_get_grant, apps_get_installation, avatars_get_screenshot,
                               migrations_get_appwrite_report, migrations_get_firebase_report,
                               migrations_get_n_host_report, migrations_get_supabase_report,
                               teams_get_membership
'set row level permissions' -> account_update_email, account_update_phone, account_update_prefs,
                               account_update_recovery, mongo_update, mysql_update,
                               postgresql_update, project_update_password_history_policy
'seed many rows at once'    -> avatars_get_screenshot, organization_get_installation,
                               teams_get_installation, teams_list_installations,
                               vcs_list_namespaces, advisor_get_report, apps_get,
                               apps_get_installation

# After
'paginated read of rows'    -> oauth2_get_grant, tables_db_list_rows, domains_get_transfer_status,
                               vcs_list_repository_branches, notifications_list
'set row level permissions' -> apps_update_labels, storage_update_file, tables_db_update_row,
                               teams_update_membership, project_update_password_…_policy
'seed many rows at once'    -> presences_get, tables_db_list_migrations, tables_db_list_rows,
                               tables_db_get_row, oauth2_list_organizations
```

`paginated read of rows` previously returned **zero** row tools. Still imperfect — `oauth2_get_grant` lingers and `presences_get` ranks first on the third query — but the noise floor is far lower and the relevant tool is now present in each.

### Inflection matching (thanks @greptile-apps)

Greptile flagged the exact-token gate as dropping valid matches. Its specific example was wrong — `list database` does return list tools, because "list" exact-matches — but the underlying concern was real and I had missed it:

```
# Broken by my first pass
'row'    -> ['tables_db_get_row']                        # list_rows dropped entirely
'rows'   -> ['tables_db_list_rows']                      # get_row dropped entirely
'bucket' -> ['storage_get_bucket', 'tokens_list']        # no list/create bucket tools

# Fixed
'row'    -> ['tables_db_get_row', 'tables_db_list_rows']
'rows'   -> ['tables_db_list_rows', 'tables_db_get_row']
'bucket' -> ['storage_get_bucket', 'tokens_list', 'storage_list_buckets']
```

I had removed containment as an *eligibility* signal when I only meant to remove it as a *noise* signal. The distinction that matters is inflection versus arbitrary containment, so that is now explicit: shared stem of ≥3 characters and a length difference of ≤2. `row`/`rows` and `policy`/`policies` match; `id`/`identity` and `of`/`profile` do not.

## 4. "read" collapsed onto `get`, burying every list tool

`_infer_query_intent` mapped "read", "fetch" and "find" to `get`, so single-item tools took a +12 intent bonus that list tools never could:

```
# Before  (scoped to tables_db)
'read rows from a table with pagination' -> get_row, get_table, get, get_status, get_column,
                                            get_index, get_migration, get_replicas
# After
'read rows from a table with pagination' -> list_rows, get_row, get_table, get
```

Eight results, not one of them a list tool. Ambiguous read words now leave get-vs-list to the resource tokens. Not in the report or my original plan — found while verifying item 3.

## 5. A near-miss tool name cost a forced search call

```
# Before
Tool tables_db_listrows was not found. Use appwrite_search_tools first.

# After
Tool tables_db_listrows was not found. Closest matches: tables_db_list_rows, tables_db_list,
tables_db_upsert_rows, tables_db_delete_rows, tables_db_list_columns.
```

## 6. Catalog resource carried no schema

Reading the whole catalog told a client nothing about parameters, so discovery meant a search call per tool. It now carries names and shapes:

```json
{
  "tool_name": "tables_db_create_string_column",
  "parameters": { "database_id": "string", "table_id": "string", "key": "string",
                  "size": "number", "required": "boolean", "default": "string" },
  "required": ["database_id", "table_id", "key", "size", "required"]
}
```

**Trade-off for a reviewer:** the resource grew 403 KB → 546 KB (981 tools, ~163 bytes each) even after truncating catalog descriptions to 200 chars. It is an opt-in read with `size` advertised, but if that is too large for real clients, dropping `description` from the catalog entirely is the obvious next cut.

## 7. A ten-row page did not fit in the preview

`PREVIEW_THRESHOLD` 800 → 4000. Under 800, stdio paid a `resources/read` for essentially every list call. HTTP is unaffected (`store_results=False`).

## 8. A write that succeeded was reported as a failure

`Service._parse_response` turns a Pydantic `ValidationError` into an exception *after* Appwrite has accepted the request, and discards the body. The model saw a wall of Pydantic and concluded failure — the report's "project creation returned false-negative Pydantic error despite successful creation" — and was liable to retry a completed mutation.

**Before**

```
Appwrite request failed: Unable to parse response into Project: 3 validation errors for Project region   Field required
```

**After** (full Pydantic detail still goes to Sentry, just not to the model)

```
Appwrite accepted the request, but the SDK could not deserialize the response, so the result
is unavailable. The operation most likely succeeded — do not retry it blindly. Verify with
the matching get or list tool for projects_create before retrying.
```

This can only hedge, because the SDK dropped the body. Recovering the actual payload needs the SDK fix (triage item 9).

---

## Deliberately not fixed here

| Report finding | Why it is not in this PR |
| --- | --- |
| `list_rows` returns no column values (T7) | Pydantic bug in the SDK, not MCP serialization as the report states: payloads are exposed via a Python `to_dict` override that pydantic-core never calls for nested models. Also hits `list_users` (`prefs: {}`), `list_documents`, `list_teams`, `list_organizations` — wider than the report found. Needs a real `@model_serializer` in the generator. **High.** |
| `columns` documented, `attributes` required | ~~API bug: Utopia binds by name, so the declared `columns` never reaches the inherited `$attributes`.~~ **Correction: this was wrong and is not a bug.** Utopia binds action arguments positionally by declaration order (`$arguments[$param['order']]` then `call_user_func_array`), so the callback's parameter names are irrelevant and `columns` arrives correctly. The confusion is real but comes from `Attributes` reporting failures in collection terminology ("Invalid type for attribute 'rating': float") whichever API was called. [appwrite/appwrite#13185](https://github.com/appwrite/appwrite/pull/13185) clears the naming split. |
| `float` advertised, `double` required | Spec description wrong (`Database::VAR_FLOAT === 'double'`); also omits `bigint` and the spatial types. |
| Bulk insert ordering dependency (T6, 51 calls vs 1) | Unconditional server-side guard; the error text does not name the workaround. |
| Unique violation reported as ID collision (T14) | `ROW_ALREADY_EXISTS` covers both cases and interpolates the requested ID, so the suggested remediation cannot work. Needs the duplicate exception to carry the violated index. |
| Query format never specified | Spec describes an SDK-only `Query` helper; the wire format is undocumented for every non-SDK consumer. |
| Relationship enums undocumented | Spec-level; the MCP surface is fixed by item 1 above since the generated schema does carry them. |
| No native join (T10) | Needs testing first — if `select(["*","author.*"])` already expands relationships this is a docs gap, not a product gap. Not filed yet. |

Also not defects: `confirm_write` / `project_id` threading (deliberate safety design, 3/5), and latency (both 4/5 — the report's own caveat is that MCP transport overhead went unmeasured, and `telemetry.py` already records per-call duration server-side).

## Testing

- 220 unit tests pass (12 new), including regression tests for each item above and for the inflection case Greptile surfaced.
- `ruff`, `black --check`, `pyright` clean; Docker build passed in CI.
- No new modules, no dependency changes, no changes to the integration suite.

