### PR TITLE
fix: publish with a twine that accepts Metadata-Version 2.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,11 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build==1.5.0 twine==6.2.0
+          # twine must be new enough for the metadata version hatchling emits.
+          # The build backend is resolved at build time and floats, so hatchling
+          # 1.32.0 moved wheels to Metadata-Version 2.5, which twine 6.2.0
+          # rejects outright ("'2.5' is not a valid metadata version").
+          pip install build==1.5.0 twine==7.0.0
 
       - name: Derive release version
         run: |
@@ -36,6 +40,11 @@ jobs:
 
       - name: Build package
         run: python -m build
+
+      # Validate before uploading, so a metadata mismatch fails with a clear
+      # message instead of surfacing mid-upload.
+      - name: Check distribution metadata
+        run: twine check dist/*
 
       - name: Publish to PyPI
         env:


### PR DESCRIPTION
The `v0.8.32` PyPI upload failed:

```
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Nothing in the package changed — the publish step aged out. `python -m build` resolves the build backend at build time and it is not pinned, so [hatchling 1.32.0](https://pypi.org/project/hatchling/1.32.0/) (released 2026-08-11, the day before the release) moved wheels to `Metadata-Version: 2.5`, while the pinned `twine==6.2.0` rejects anything above 2.4.

Reproduced locally against `main`, building the same way CI does:

```
$ python -m build --wheel && python -c "…read METADATA…"
dist/mcp_server_appwrite-0.8.32-py3-none-any.whl
['Metadata-Version: 2.5']

$ twine==6.2.0 check dist/*.whl
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version

$ twine==7.0.0 check dist/*.whl        # packaging 26.3
PASSED
```

Two changes:
* `twine==6.2.0` → `twine==7.0.0`.
* A `twine check dist/*` step before the upload, so the next metadata mismatch fails with a clear message instead of surfacing part-way through an upload.

Left the build backend unpinned deliberately — pinning it would trade this failure mode for stale-backend maintenance, and the actual defect was that twine had fallen behind. Worth a follow-up if it recurs.

`v0.8.32` Docker images published fine (Production deployment succeeded); only PyPI and the MCP Registry job (which is `needs: publish`) were left undone. Once this merges I will re-trigger the release publish so `0.8.32` lands on PyPI rather than burning a version number.