### PR TITLE
chore: pin build backend and dev tooling, and build CI from the lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           version: "0.11.22"
 
       - name: Install dev dependencies
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
 
       - name: Lint
         run: uv run --group dev ruff check src tests
@@ -54,7 +54,7 @@ jobs:
           version: "0.11.22"
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --frozen
 
       - name: Run unit tests
         run: uv run python -m unittest discover -s tests/unit -v
@@ -92,7 +92,7 @@ jobs:
           version: "0.11.22"
 
       - name: Install dependencies
-        run: uv sync --extra integration
+        run: uv sync --frozen --extra integration
 
       - name: Run integration tests
         run: uv run --extra integration python -m unittest discover -s tests/integration -v

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          # twine must be new enough for the metadata version hatchling emits.
-          # The build backend is resolved at build time and floats, so hatchling
-          # 1.32.0 moved wheels to Metadata-Version 2.5, which twine 6.2.0
-          # rejects outright ("'2.5' is not a valid metadata version").
           pip install build==1.5.0 twine==7.0.0
 
       - name: Derive release version
@@ -41,8 +37,6 @@ jobs:
       - name: Build package
         run: python -m build
 
-      # Validate before uploading, so a metadata mismatch fails with a clear
-      # message instead of surfacing mid-upload.
       - name: Check distribution metadata
         run: twine check dist/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ integration = [
 
 [dependency-groups]
 dev = [
-    "black>=25.1.0",
-    "ruff>=0.10.0",
-    "pyright>=1.1.390",
+    "black==26.3.1",
+    "ruff==0.15.18",
+    "pyright==1.1.411",
     # Only needed by scripts/build_docs_index.py to (re)build the docs index.
-    "pyyaml>=6.0",
+    "pyyaml==6.0.3",
 ]
 
 [project.scripts]
@@ -70,5 +70,5 @@ venv = ".venv"
 typeCheckingMode = "basic"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling==1.32.0", "hatch-vcs==0.5.0"]
 build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -718,10 +718,10 @@ provides-extras = ["integration"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=25.1.0" },
-    { name = "pyright", specifier = ">=1.1.390" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "ruff", specifier = ">=0.10.0" },
+    { name = "black", specifier = "==26.3.1" },
+    { name = "pyright", specifier = "==1.1.411" },
+    { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "ruff", specifier = "==0.15.18" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to #96. That PR fixed the symptom (twine too old for `Metadata-Version: 2.5`); this fixes the cause.

## Why v0.8.32 broke

The build frontend resolves `[build-system] requires` in an isolated environment at build time, and it was unpinned:

```toml
requires = ["hatchling", "hatch-vcs"]
```

So [hatchling 1.32.0](https://pypi.org/project/hatchling/1.32.0/), released the day before, moved the wheel from `Metadata-Version: 2.4` to `2.5` on a commit that touched nothing in the package. A release is only as reproducible as the loosest thing it resolves.

## Changes

**`[build-system]` pinned exactly** — `hatchling==1.32.0`, `hatch-vcs==0.5.0`. Build-time only, so no consumer impact.

**Dev group pinned exactly** — `black==26.3.1`, `ruff==0.15.18`, `pyright==1.1.411`, `pyyaml==6.0.3`. Dependency groups are never published, so this costs consumers nothing, and it stops a new ruff or black release failing CI on an untouched commit.

**CI installs from the lockfile** — `uv sync` had no `--frozen` in any of the three jobs, so CI could resolve versions the lock did not contain and drift from the Docker image, which has always used `uv sync --frozen --no-dev`:

```diff
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
-        run: uv sync
+        run: uv sync --frozen
-        run: uv sync --extra integration
+        run: uv sync --frozen --extra integration
```

`uv.lock` regenerated so `--frozen` matches the new dev requirements.

## What is deliberately not pinned

Runtime `dependencies` keep their ranges. This package is published to PyPI, so `==` pins there would make it unresolvable alongside a consumer's own dependencies, and every bump would need a PR. `uv.lock` already pins them exactly, and now every build path — CI and Docker — installs from it. That gives reproducible builds without pushing our pins onto consumers.

The published `integration` extra is left as ranges for the same reason.

## Verification

Built the wheel with the pinned backend and ran the check step `publish.yml` now performs:

```
$ python -m build --wheel
Successfully built mcp_server_appwrite-0.8.33-py3-none-any.whl
$ twine check dist/*.whl
PASSED
```

`ruff`, `black --check` and `pyright` clean, and 221 unit tests pass with the pinned tool versions under `uv sync --frozen`.
