### PR TITLE
fix: document the query wire format on the MCP surface

### DIFF
--- a/src/mcp_server_appwrite/docs.py
+++ b/src/mcp_server_appwrite/docs.py
@@ -1,17 +1,9 @@
 """Documentation the SDK docstrings deliberately leave to helper classes.
 
-The Appwrite API spec describes `queries` in terms of the `Query` class each SDK
-ships, which is intentional — SDK users should reach for the helper rather than
-hand-build query strings. An MCP client has no such helper: it sends JSON over
-`appwrite_call_tool`, so the wire format is the only thing it can act on, and
-nothing in the generated description states it.
-
-This module supplies that missing half for the MCP surface. It documents how to
-address the API, and never corrects a defect: anything wrong upstream belongs
-upstream, where every SDK benefits rather than this one client.
-
-Not to be confused with `docs_search.py`, which searches the Appwrite product
-documentation for the user.
+The spec describes `queries` via each SDK's `Query` class, which is intentional.
+An MCP client has no helper — it sends JSON — so the wire format is all it can
+act on, and nothing generated states it. This documents how to address the API;
+defects belong upstream, where every SDK benefits. Unrelated to `docs_search.py`.
 """
 
 from __future__ import annotations

--- a/src/mcp_server_appwrite/docs.py
+++ b/src/mcp_server_appwrite/docs.py
@@ -1,4 +1,4 @@
-"""Parameter documentation the SDK docstrings deliberately leave to helper classes.
+"""Documentation the SDK docstrings deliberately leave to helper classes.
 
 The Appwrite API spec describes `queries` in terms of the `Query` class each SDK
 ships, which is intentional — SDK users should reach for the helper rather than
@@ -6,9 +6,12 @@ hand-build query strings. An MCP client has no such helper: it sends JSON over
 `appwrite_call_tool`, so the wire format is the only thing it can act on, and
 nothing in the generated description states it.
 
-This module supplies that missing half for the MCP surface. It documents the
-encoding of a parameter, never corrects a defect — anything wrong upstream
-belongs upstream, where every SDK benefits.
+This module supplies that missing half for the MCP surface. It documents how to
+address the API, and never corrects a defect: anything wrong upstream belongs
+upstream, where every SDK benefits rather than this one client.
+
+Not to be confused with `docs_search.py`, which searches the Appwrite product
+documentation for the user.
 """
 
 from __future__ import annotations

--- a/src/mcp_server_appwrite/docs.py
+++ b/src/mcp_server_appwrite/docs.py
@@ -12,8 +12,8 @@ QUERIES_GUIDANCE = (
     "Each query is its own JSON string, e.g. "
     '{"method":"greaterThanEqual","attribute":"rating","values":[2]}. Filters '
     "take attribute and values: equal, notEqual, lessThan, lessThanEqual, "
-    "greaterThan, greaterThanEqual, between, isNull, isNotNull, startsWith, "
-    "endsWith, contains, search. orderAsc and orderDesc take attribute only. "
+    "greaterThan, greaterThanEqual, between, startsWith, endsWith, contains, "
+    "search. isNull, isNotNull, orderAsc and orderDesc take attribute only. "
     "limit, offset, cursorAfter and cursorBefore take values only. On list "
     "endpoints a relationship returns only the related ID unless selected: "
     '{"method":"select","values":["*","author.*"]} expands it in the same call, '

--- a/src/mcp_server_appwrite/parameter_docs.py
+++ b/src/mcp_server_appwrite/parameter_docs.py
@@ -1,0 +1,48 @@
+"""Parameter documentation the SDK docstrings deliberately leave to helper classes.
+
+The Appwrite API spec describes `queries` in terms of the `Query` class each SDK
+ships, which is intentional — SDK users should reach for the helper rather than
+hand-build query strings. An MCP client has no such helper: it sends JSON over
+`appwrite_call_tool`, so the wire format is the only thing it can act on, and
+nothing in the generated description states it.
+
+This module supplies that missing half for the MCP surface. It documents the
+encoding of a parameter, never corrects a defect — anything wrong upstream
+belongs upstream, where every SDK benefits.
+"""
+
+from __future__ import annotations
+
+QUERIES_GUIDANCE = (
+    "Each query is its own JSON string, e.g. "
+    '{"method":"greaterThanEqual","attribute":"rating","values":[2]}. Filters '
+    "take attribute and values: equal, notEqual, lessThan, lessThanEqual, "
+    "greaterThan, greaterThanEqual, between, isNull, isNotNull, startsWith, "
+    "endsWith, contains, search. orderAsc and orderDesc take attribute only. "
+    "limit, offset, cursorAfter and cursorBefore take values only. On list "
+    "endpoints a relationship returns only the related ID unless selected: "
+    '{"method":"select","values":["*","author.*"]} expands it in the same call, '
+    "avoiding one call per row."
+)
+
+# Applied to every tool that declares the parameter, keyed by name.
+PARAMETER_GUIDANCE: dict[str, str] = {
+    "queries": QUERIES_GUIDANCE,
+}
+
+
+def describe_parameter(parameter_name: str, description: str) -> str:
+    """Return ``description`` prefixed with this parameter's wire-format notes.
+
+    The guidance leads rather than trails: search output truncates long
+    parameter descriptions, and the SDK text is long enough on its own to
+    consume the budget.
+    """
+    guidance = PARAMETER_GUIDANCE.get(parameter_name)
+    if guidance is None:
+        return description
+
+    base = description.strip()
+    if not base:
+        return guidance
+    return f"{guidance} {base}"

--- a/src/mcp_server_appwrite/service.py
+++ b/src/mcp_server_appwrite/service.py
@@ -8,6 +8,8 @@ from appwrite_console.input_file import InputFile
 from docstring_parser import parse
 from mcp.types import Tool
 
+from .parameter_docs import describe_parameter
+
 
 class Service:
     """Base class for all Appwrite services"""
@@ -187,13 +189,17 @@ class Service:
 
                 param_type = type_hints.get(param_name, str)
                 properties[param_name] = self.python_type_to_json_schema(param_type)
-                properties[param_name]["description"] = f"Parameter '{param_name}'"
+                description = f"Parameter '{param_name}'"
 
                 for doc_param in docstring.params:
                     if doc_param.arg_name == param_name:
-                        properties[param_name]["description"] = self._clean_description(
+                        description = self._clean_description(
                             doc_param.description or ""
                         )
+
+                properties[param_name]["description"] = describe_parameter(
+                    param_name, description
+                )
 
                 if param.default is param.empty:
                     required.append(param_name)

--- a/src/mcp_server_appwrite/service.py
+++ b/src/mcp_server_appwrite/service.py
@@ -8,7 +8,7 @@ from appwrite_console.input_file import InputFile
 from docstring_parser import parse
 from mcp.types import Tool
 
-from .parameter_docs import describe_parameter
+from .docs import describe_parameter
 
 
 class Service:

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,0 +1,91 @@
+import json
+import unittest
+
+from appwrite_console.query import Query
+
+from mcp_server_appwrite.docs import QUERIES_GUIDANCE, describe_parameter
+
+# Each group as the guidance describes it, checked against what the SDK's Query
+# class actually emits. Grouping a value-taking method as attribute-only (or the
+# reverse) tells clients to build a query the API does not accept.
+TAKES_ATTRIBUTE_AND_VALUES = {
+    "equal": Query.equal("a", 1),
+    "notEqual": Query.not_equal("a", 1),
+    "lessThan": Query.less_than("a", 1),
+    "lessThanEqual": Query.less_than_equal("a", 1),
+    "greaterThan": Query.greater_than("a", 1),
+    "greaterThanEqual": Query.greater_than_equal("a", 1),
+    "between": Query.between("a", 1, 2),
+    "startsWith": Query.starts_with("a", "x"),
+    "endsWith": Query.ends_with("a", "x"),
+    "contains": Query.contains("a", "x"),
+    "search": Query.search("a", "x"),
+}
+
+TAKES_ATTRIBUTE_ONLY = {
+    "isNull": Query.is_null("a"),
+    "isNotNull": Query.is_not_null("a"),
+    "orderAsc": Query.order_asc("a"),
+    "orderDesc": Query.order_desc("a"),
+}
+
+TAKES_VALUES_ONLY = {
+    "limit": Query.limit(10),
+    "offset": Query.offset(10),
+    "cursorAfter": Query.cursor_after("a"),
+    "cursorBefore": Query.cursor_before("a"),
+}
+
+
+class QueryGuidanceTests(unittest.TestCase):
+    def test_attribute_and_value_methods_emit_both(self):
+        for method, emitted in TAKES_ATTRIBUTE_AND_VALUES.items():
+            with self.subTest(method=method):
+                query = json.loads(emitted)
+                self.assertEqual(query["method"], method)
+                self.assertIn("attribute", query)
+                self.assertIn("values", query)
+
+    def test_attribute_only_methods_emit_no_values(self):
+        for method, emitted in TAKES_ATTRIBUTE_ONLY.items():
+            with self.subTest(method=method):
+                query = json.loads(emitted)
+                self.assertEqual(query["method"], method)
+                self.assertIn("attribute", query)
+                self.assertNotIn("values", query)
+
+    def test_value_only_methods_emit_no_attribute(self):
+        for method, emitted in TAKES_VALUES_ONLY.items():
+            with self.subTest(method=method):
+                query = json.loads(emitted)
+                self.assertEqual(query["method"], method)
+                self.assertNotIn("attribute", query)
+                self.assertIn("values", query)
+
+    def test_guidance_names_every_method_in_its_correct_group(self):
+        attribute_and_values, attribute_only, values_only = (
+            QUERIES_GUIDANCE.split("take attribute and values:")[1].split(
+                "take attribute only."
+            )[0],
+            QUERIES_GUIDANCE.split("take attribute only.")[0].rsplit(".", 2)[-1],
+            QUERIES_GUIDANCE.split("take values only.")[0].rsplit(".", 1)[-1],
+        )
+
+        for method in TAKES_ATTRIBUTE_AND_VALUES:
+            self.assertIn(method, attribute_and_values, method)
+        for method in TAKES_ATTRIBUTE_ONLY:
+            self.assertIn(method, attribute_only, method)
+        for method in TAKES_VALUES_ONLY:
+            self.assertIn(method, values_only, method)
+
+    def test_examples_match_the_sdk_helper(self):
+        # The documented examples must stay identical to the canonical producer.
+        self.assertIn(Query.greater_than_equal("rating", 2), QUERIES_GUIDANCE)
+        self.assertIn(Query.select(["*", "author.*"]), QUERIES_GUIDANCE)
+
+    def test_unknown_parameter_is_untouched(self):
+        self.assertEqual(describe_parameter("search", "Search term."), "Search term.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from appwrite_console.input_file import InputFile
 
-from mcp_server_appwrite.parameter_docs import QUERIES_GUIDANCE
+from mcp_server_appwrite.docs import QUERIES_GUIDANCE
 from mcp_server_appwrite.service import Service
 
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 
 from appwrite_console.input_file import InputFile
 
+from mcp_server_appwrite.parameter_docs import QUERIES_GUIDANCE
 from mcp_server_appwrite.service import Service
 
 
@@ -50,6 +51,22 @@ class ExampleService:
         return {"ok": True}
 
 
+class QueryService:
+    def list(self, queries: List[str] = [], search: str = "") -> Dict[str, Any]:
+        """
+        List example resources.
+
+        Parameters
+        ----------
+        queries : List[str]
+            Array of query strings generated using the Query class provided by the SDK.
+        search : str
+            Search term to filter your list results.
+        """
+
+        return {"total": 0}
+
+
 class ServiceSchemaTests(unittest.TestCase):
     def test_generates_enum_and_input_file_schema(self):
         tools = Service(ExampleService(), "example").list_tools()
@@ -66,6 +83,32 @@ class ServiceSchemaTests(unittest.TestCase):
         self.assertIn("oneOf", schema["properties"]["file"])
         self.assertIn("file", schema["required"])
         self.assertTrue(schema["additionalProperties"] is False)
+
+    def test_documents_the_query_wire_format(self):
+        properties = (
+            Service(QueryService(), "example")
+            .list_tools()["example_list"]["definition"]
+            .input_schema["properties"]
+        )
+        description = properties["queries"]["description"]
+
+        # An MCP client has no Query helper class, so the encoding is the only
+        # actionable part. It leads, because search output truncates.
+        self.assertTrue(description.startswith(QUERIES_GUIDANCE))
+        self.assertIn('{"method":"greaterThanEqual"', description)
+        self.assertIn("Query class provided by the SDK", description)
+
+    def test_leaves_other_parameters_untouched(self):
+        properties = (
+            Service(QueryService(), "example")
+            .list_tools()["example_list"]["definition"]
+            .input_schema["properties"]
+        )
+
+        self.assertEqual(
+            properties["search"]["description"],
+            "Search term to filter your list results.",
+        )
 
     def test_filters_methods_and_carries_context_metadata(self):
         tools = Service(


### PR DESCRIPTION
Last of the [MCP benchmark](https://6a79b8b74e1f6bf83f68.appwrite.network/) round-trip findings — "query format never specified", which was one of the two axes scored 2/5.

I originally triaged this as a spec problem for `appwrite/appwrite`. It isn't: describing `queries` in terms of the `Query` helper is intentional, because SDK users *should* reach for the helper instead of hand-building query strings. An MCP client has no helper — it sends JSON through `appwrite_call_tool` — so the encoding is the only thing it can act on, and the generated description never states it. That makes this ours to document, not theirs to change.

## Before

All 120 list tools, verbatim:

```
- queries (array[string], optional): Array of query strings generated using the Query class
  provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum
  of 100 queries are allowed, each 4096 characters long.
```

Actionable for an SDK user; a dead end for an MCP client.

## After

```
- queries (array[string], optional): Each query is its own JSON string, e.g.
  {"method":"greaterThanEqual","attribute":"rating","values":[2]}. Filters take attribute and
  values: equal, notEqual, lessThan, lessThanEqual, greaterThan, greaterThanEqual, between,
  isNull, isNotNull, startsWith, endsWith, contains, search. orderAsc and orderDesc take
  attribute only. limit, offset, cursorAfter and cursorBefore take values only. On list
  endpoints a relationship returns only the related ID unless selected:
  {"method":"select","values":["*","author.*"]} expands it in the same call, avoiding one call
  per row. Array of query strings generated using the Query class provided by the SDK. […]
```

The SDK text is kept — the guidance leads because search output truncates long descriptions, and the SDK half is long enough on its own to consume the budget.

## The relationship half

This also closes the benchmark's T10 result (one call per row to read a relationship), which I had triaged as possibly a missing feature. It is not — expansion already works. Verified live against Cloud (`fra`, TablesDB, `books` manyToOne `authors`), read over plain REST to bypass the SDK serialization bug:

```
# no select — the foreign key only
GET /tablesdb/…/books/rows
  "author": "a1"

# select with a relationship path — fully expanded, single call
GET /tablesdb/…/books/rows?queries[]={"method":"select","values":["*","author.*"]}
  "author": {"name": "Ada Lovelace", "$id": "a1", …}
```

The trap worth documenting is that `createRow` returns the related row **fully populated with no select at all**, so the shape differs between write and list responses with nothing to indicate that `select` is the switch. A client that sees the expanded object on write reasonably assumes list matches, finds a bare ID, and falls back to N+1 — which is what the benchmark did.

## Scope

One parameter, keyed by name, applied wherever it appears. `docs.py` documents *how to address the API*; it is not a correction layer. Its docstring notes the distinction from `docs_search.py`, which searches the product documentation for the user. Everything that was actually wrong upstream has stayed upstream and is now fixed or in review there ([#13185](https://github.com/appwrite/appwrite/pull/13185), [#13186](https://github.com/appwrite/appwrite/pull/13186), [#13187](https://github.com/appwrite/appwrite/pull/13187), [sdk-generator#1776](https://github.com/appwrite/sdk-generator/pull/1776), [#1777](https://github.com/appwrite/sdk-generator/pull/1777)), so nothing here duplicates a fix that belongs elsewhere. The module docstring states that boundary so the file does not accumulate defect workarounds later.

## Verification

- Both JSON examples are byte-identical to what the SDK's `Query` class emits, so the documented format cannot drift from the canonical producer:
  ```
  Query.greater_than_equal("rating", 2) -> {"method":"greaterThanEqual","attribute":"rating","values":[2]}
  Query.select(["*", "author.*"])       -> {"method":"select","values":["*","author.*"]}
  ```
- Guidance is 566 chars against the 600-char render budget, so it survives truncation whole. My first draft was 618 and clipped its own last clause; tightened rather than raising the limit.
- Applies to all 120 tools that declare `queries`; other parameters are untouched (covered by a test).
- 223 unit tests pass (2 new). `ruff`, `black --check`, `pyright` clean under `uv sync --frozen`.
