### PR TITLE
chore: upgrade appwrite-console to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "anyio>=4.0.0",
-    "appwrite-console>=0.3.0,<0.4",
+    "appwrite-console>=0.5.0,<0.6",
     "docstring-parser>=0.16",
     "mcp[cli]>=2,<3",
     "python-dotenv>=1.0.1",

--- a/src/mcp_server_appwrite/catalog_policy.py
+++ b/src/mcp_server_appwrite/catalog_policy.py
@@ -101,6 +101,7 @@ API_KEY_EXCLUDED_METHODS: dict[str, frozenset[str]] = {
     "tables_db": frozenset(
         {
             "create_migration",
+            "cutover_migration",
             "delete_migration",
             "get_migration",
             "list_migrations",

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -976,7 +976,7 @@ def _format_tool_result(
 
 def _format_appwrite_error(exc: AppwriteException, tool_name: str | None = None) -> str:
     if is_response_parse_error(exc):
-        return _format_response_parse_error(tool_name)
+        return _format_response_parse_error(tool_name, _parse_error_response(exc))
 
     details = []
     if getattr(exc, "code", None):
@@ -990,14 +990,30 @@ def _format_appwrite_error(exc: AppwriteException, tool_name: str | None = None)
     return f"Appwrite request failed{detail_text}: {message}"
 
 
-def _format_response_parse_error(tool_name: str | None) -> str:
+def _parse_error_response(exc: BaseException) -> Any:
+    """The raw body the SDK failed to hydrate, if it kept one."""
+    for item in (exc, exc.__cause__, exc.__context__):
+        response = getattr(item, "response", None)
+        if response is not None:
+            return response
+    return None
+
+
+def _format_response_parse_error(tool_name: str | None, response: Any = None) -> str:
     """Explain an SDK deserialization failure without implying the write failed.
 
     ``Service._parse_response`` raises this after Appwrite has already accepted
-    the request, and it discards the response body, so the operation usually
-    succeeded. Reporting the raw Pydantic error invites the model to retry a
+    the request, so the operation succeeded even though the result could not be
+    hydrated. Reporting the raw Pydantic error invites the model to retry a
     completed mutation.
     """
+    if response is not None:
+        return (
+            "Appwrite accepted the request and it succeeded; the SDK could not "
+            "deserialize the response into its model, so the raw payload "
+            f"follows. Do not retry.\n{_serialize_result(response)}"
+        )
+
     verify = (
         f" Verify with the matching get or list tool for {tool_name} before retrying."
         if tool_name

--- a/tests/integration/test_tables_db.py
+++ b/tests/integration/test_tables_db.py
@@ -47,6 +47,13 @@ class TablesDbIntegrationTests(LiveIntegrationTestCase):
                 "tables_db_get_row",
                 {"database_id": database_id, "table_id": table_id, "row_id": "row1"},
             )
+
+            listed = runner.call(
+                "tables_db_list_rows",
+                {"database_id": database_id, "table_id": table_id},
+            )
+            self.assertEqual(listed["rows"][0]["$id"], "row1")
+            self.assertEqual(listed["rows"][0]["data"]["name"], "smoke")
         finally:
             try:
                 runner.call(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -13,6 +13,7 @@ import mcp.types as types
 from appwrite_console.enums.browser import Browser
 from appwrite_console.exception import AppwriteException
 from appwrite_console.input_file import InputFile
+from appwrite_console.models.row_list import RowList
 
 from mcp_server_appwrite import server as server_module
 from mcp_server_appwrite.catalog_policy import API_KEY_PROFILE, OAUTH_PROFILE
@@ -427,6 +428,48 @@ class ServerHelperTests(unittest.TestCase):
         self.assertLess(len(message), 560)
         self.assertTrue(message.endswith("..."))
 
+    def test_format_tool_result_keeps_nested_row_columns(self):
+        row_list = RowList.with_data(
+            {
+                "total": 1,
+                "rows": [
+                    {
+                        "$id": "b01",
+                        "$sequence": "1",
+                        "$tableId": "books",
+                        "$databaseId": "library",
+                        "$createdAt": "2026-01-01T00:00:00.000+00:00",
+                        "$updatedAt": "2026-01-01T00:00:00.000+00:00",
+                        "$permissions": [],
+                        "title": "Dune",
+                        "rating": 4.5,
+                    }
+                ],
+            }
+        )
+
+        result = _format_tool_result("tables_db_list_rows", row_list, {})
+
+        # Listing rows returned IDs with no column values until the SDK stopped
+        # dropping nested payloads; pin it so a regression is loud.
+        self.assertIn('"title": "Dune"', result[0].text)
+        self.assertIn('"rating": 4.5', result[0].text)
+
+    def test_format_appwrite_error_returns_the_unhydrated_payload(self):
+        exc = AppwriteException(
+            "Unable to parse response into Project: 1 validation error",
+            response={"$id": "proj-1", "name": "New Project"},
+        )
+
+        message = _format_appwrite_error(exc, tool_name="projects_create")
+
+        # The SDK now keeps the body, so the model gets the result of the write
+        # rather than a hedge and a re-fetch.
+        self.assertIn("it succeeded", message)
+        self.assertIn("Do not retry", message)
+        self.assertIn('"$id": "proj-1"', message)
+        self.assertNotIn("validation error", message)
+
     def test_format_appwrite_error_does_not_report_parse_failure_as_failure(self):
         exc = AppwriteException(
             "Unable to parse response into Project: 1 validation error for Project"
@@ -598,8 +641,8 @@ class ServerHelperTests(unittest.TestCase):
             {service.service_name for service in manager_a.services},
             set(SERVICE_CLASSES),
         )
-        self.assertEqual(len(manager_a.services), 38)
-        self.assertEqual(len(manager_a.get_all_tools()), 981)
+        self.assertEqual(len(manager_a.services), 39)
+        self.assertEqual(len(manager_a.get_all_tools()), 992)
 
     def test_api_key_profile_only_advertises_server_capabilities(self):
         manager = register_services(object(), profile=API_KEY_PROFILE)
@@ -607,13 +650,15 @@ class ServerHelperTests(unittest.TestCase):
         tool_names = {tool.name for tool in manager.get_all_tools()}
 
         self.assertEqual(len(manager.services), 26)
-        self.assertEqual(len(tool_names), 647)
+        self.assertEqual(len(tool_names), 650)
         self.assertIn("documents_db_list", tool_names)
         self.assertIn("vectors_db_list", tool_names)
         self.assertIn("embeddings_create_text_embeddings", tool_names)
         self.assertNotIn("domains", service_names)
         self.assertNotIn("organizations", service_names)
         self.assertNotIn("documents_db_list_operations", tool_names)
+        self.assertNotIn("tables_db_cutover_migration", tool_names)
+        self.assertNotIn("affiliates", service_names)
         self.assertNotIn("account_list_invoices", tool_names)
 
     def test_console_sdk_internal_model_type_is_never_advertised(self):

--- a/uv.lock
+++ b/uv.lock
@@ -39,15 +39,15 @@ wheels = [
 
 [[package]]
 name = "appwrite-console"
-version = "0.3.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/2e/225524a64d849dffc1580c65efa1f2797962a9018c18c6332cbf65ebaa38/appwrite_console-0.3.0.tar.gz", hash = "sha256:8065c9e29fe4d8c75e565a9e14b94e1822f080afe408380c50adf5fa4d50955f", size = 294701, upload-time = "2026-08-04T11:58:52.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/8a/e03a30411b33431ead5b68d1101e09e8992d8295aaf1e550fafd11aa84e3/appwrite_console-0.5.0.tar.gz", hash = "sha256:e8a1edb3cbc47fea6aacc7df124e20e3fb1facdbfbb5ed8f2594ddfde56190b5", size = 302041, upload-time = "2026-08-12T13:33:28.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/f2/7d144e6cf5c877b57b26da230af9f771695ebd229f6b096ece567084bd52/appwrite_console-0.3.0-py3-none-any.whl", hash = "sha256:83497d711ac0aa8e30b67b62c9423b216ee7a20ddc4b1202b8656bf1f0bd1f21", size = 517531, upload-time = "2026-08-04T11:58:51.097Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/47/185b10c036d9dfce3c23eae97b873598416748cce24f6b8605800ad70b0a/appwrite_console-0.5.0-py3-none-any.whl", hash = "sha256:07d11dfaa8989bcfd0335a254e7e9296a4dff8fb3beb3e9d061719ccd7b5288e", size = 530460, upload-time = "2026-08-12T13:33:27.366Z" },
 ]
 
 [[package]]
@@ -695,7 +695,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0.0" },
-    { name = "appwrite-console", specifier = ">=0.3.0,<0.4" },
+    { name = "appwrite-console", specifier = ">=0.5.0,<0.6" },
     { name = "argon2-cffi", marker = "extra == 'integration'", specifier = ">=23.1.0" },
     { name = "bcrypt", marker = "extra == 'integration'", specifier = ">=4.1.2" },
     { name = "docstring-parser", specifier = ">=0.16" },


### PR DESCRIPTION
Picks up [sdk-for-console-python 0.5.0](https://github.com/appwrite/sdk-for-console-python/releases/tag/0.5.0), which carries both Python SDK serialization fixes ([sdk-generator#1776](https://github.com/appwrite/sdk-generator/pull/1776), [#1777](https://github.com/appwrite/sdk-generator/pull/1777)).

`>=0.3.0,<0.4` → `>=0.5.0,<0.6`, skipping 0.4.0 entirely (it predated both fixes).

## What the upgrade fixes

The benchmark's headline defect, T7 — verified against the installed 0.5.0 models:

```python
RowList.with_data({"total": 1, "rows": [{... "title": "Dune", "rating": 4.5}]}).to_dict()

# 0.3.0 — column values dropped, so reading one page cost 10 extra get_row calls
{'total': 1.0, 'rows': [{'$id': 'b01', …, '$permissions': []}]}

# 0.5.0
{'total': 1.0, 'rows': [{'$id': 'b01', …, 'data': {'title': 'Dune', 'rating': 4.5}}]}
```

Nested `prefs` now matches the REST shape rather than being emptied or double-wrapped:

```python
UserList…to_dict()["users"][0]["prefs"]   # 0.3.0: {}   →  0.5.0: {'theme': 'dark'}
Preferences.with_data({"theme": "dark"}).to_dict()  # {'data': {…}}  →  {'theme': 'dark'}
```

## Using the recovered response body

`AppwriteException` now carries `response`, so a hydration failure no longer has to hedge. Appwrite accepted the request and it succeeded — only the model binding failed — so the payload goes back to the client:

```
# before
Appwrite accepted the request, but the SDK could not deserialize the response, so the result
is unavailable. The operation most likely succeeded — do not retry it blindly. Verify with the
matching get or list tool for projects_create before retrying.

# after
Appwrite accepted the request and it succeeded; the SDK could not deserialize the response
into its model, so the raw payload follows. Do not retry.
{ "$id": "proj-1", "name": "New Project" }
```

That removes the re-fetch the benchmark hit on project creation. The hedging branch is kept for older SDKs or any path that arrives without a body.

## Surface change, and one policy gap it opened

I diffed the generated catalog across the upgrade rather than trusting the version bump, because `catalog_policy.py` hardcodes method names:

```
services: 38 → 39      tools: 981 → 992
removed: 0
added:   affiliates_* (7), project_update_mfa_factors_policy, proxy_create_invalidation,
         tables_db_cutover_migration, users_get_mfa_challenge
```

Nothing removed, so no broken references. But `tables_db_cutover_migration` lands on `/tablesdb/{databaseId}/migrations/{migrationId}/cutover` — the same resource family as `create_migration`, `get_migration`, `list_migrations` and `delete_migration`, all four already withheld from API-key mode as console operations. Left alone, the upgrade would have quietly widened the API-key surface with a console-only operation, so it is now excluded with them.

`affiliates` (referral links and rewards) needs no change: it is absent from `API_KEY_SERVICES`, and the allowlist is deny-by-default, so it stays out of API-key mode until deliberately reviewed. It is console-scoped for OAuth, which is correct for account-level functionality.

Both are now asserted by name instead of being implicit in a tool count — a count alone would not have said *which* tools moved.

## Verification

- 231 unit tests pass (2 new); `ruff`, `black --check`, `pyright` clean under `uv sync --frozen`.
- Two hardcoded surface counts updated (`38 → 39` services, `647 → 650` API-key tools). The API-key delta is exactly the 3 expected: 11 new tools, minus 7 `affiliates` and minus `cutover_migration`, which is how I confirmed the exclusion took effect.
- Re-added the integration assertion that a listed row carries its column values. It was removed when the workaround came out, because it could not pass against 0.3.0; it is meaningful again now.
- `uv.lock` regenerated so `--frozen` stays consistent across CI and Docker.
