### PR TITLE
fix: support modern MCP subscriptions

### DIFF
--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -38,6 +38,7 @@ from mcp import MCPError
 from mcp.server import NotificationOptions, Server, ServerRequestContext
 from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.models import InitializationOptions
+from mcp.server.subscriptions import InMemorySubscriptionBus, ListenHandler
 from mcp.types import CLIENT_INFO_META_KEY, INVALID_PARAMS
 
 from . import error_monitoring, flags, telemetry
@@ -1068,6 +1069,7 @@ def build_instructions(transport: str = "http") -> str:
 def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
     _configure_uploads(transport)
     instructions = build_instructions(transport)
+    subscriptions = ListenHandler(InMemorySubscriptionBus())
 
     async def handle_list_tools(
         ctx: ServerRequestContext, params: types.PaginatedRequestParams | None
@@ -1302,6 +1304,7 @@ def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
         on_list_resources=handle_list_resources,
         on_list_resource_templates=handle_list_resource_templates,
         on_read_resource=handle_read_resource,
+        on_subscriptions_listen=subscriptions,
     )
 
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -165,6 +165,11 @@ class ServerHelperTests(unittest.TestCase):
         self.assertIn("Large results are stored as resources", stdio)
         self.assertIn("returns tool results inline", http)
 
+    def test_build_mcp_server_supports_modern_subscriptions(self):
+        server = build_mcp_server(Mock(), transport="http")
+
+        self.assertIsNotNone(server.get_request_handler("subscriptions/listen"))
+
     def test_build_mcp_server_reports_appwrite_metadata(self):
         server = build_mcp_server(Mock(), transport="stdio")
         options = server.create_initialization_options()


### PR DESCRIPTION
Antigravity negotiates MCP `2026-07-28` and opens a subscription stream before listing tools. The server did not register that handler, so OAuth succeeded but setup ended with:

```text
sending "subscriptions/listen": session not found
```

Register `ListenHandler` with an in-memory subscription bus on the low-level server. Earlier MCP clients continue using the existing handlers unchanged.

## Verification

```text
Antigravity + patched local server: ready, 4 Appwrite tools loaded
uv run --group dev ruff check src tests
uv run --group dev black --check src tests
uv run python -m unittest discover -s tests/unit -v  # 232 passed
```
