### PR TITLE
fix: accept normalized root resource audience

### DIFF
--- a/src/mcp_server_appwrite/auth.py
+++ b/src/mcp_server_appwrite/auth.py
@@ -99,9 +99,13 @@ def mcp_path_resource() -> str:
     return f"{public_base_url()}/mcp"
 
 
-def accepted_resources() -> tuple[str, str]:
-    """Resource audiences accepted by the two shared MCP endpoints."""
-    return canonical_resource(), mcp_path_resource()
+def accepted_resources() -> tuple[str, str, str]:
+    """Resource audiences accepted by the two shared MCP endpoints.
+
+    Some clients normalize an origin-only resource URI by dropping its trailing
+    slash. Accept that equivalent spelling alongside the advertised root URI.
+    """
+    return canonical_resource(), public_base_url(), mcp_path_resource()
 
 
 def resource_metadata_url(resource: str | None = None) -> str:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -428,6 +428,12 @@ class AudienceTests(unittest.TestCase):
     def test_audience_match_string(self):
         self.assertEqual(self.verifier._accepted_resource(self.resource), self.resource)
 
+    def test_root_audience_without_trailing_slash_matches(self):
+        root_without_slash = "https://mcp.appwrite.io"
+        self.assertEqual(
+            self.verifier._accepted_resource(root_without_slash), root_without_slash
+        )
+
     def test_mcp_path_audience_match_string(self):
         self.assertEqual(
             self.verifier._accepted_resource(self.mcp_path_resource),


### PR DESCRIPTION
Antigravity strips the trailing slash from an origin-only OAuth resource. The root endpoint advertises `https://mcp.appwrite.io/`, but Antigravity requests a token for `https://mcp.appwrite.io`; the verifier rejected that equivalent audience.

```text
advertised root resource: https://mcp.appwrite.io/
token audience:           https://mcp.appwrite.io
before: initialize -> Unauthorized
after:  both root spellings are accepted
```

`/mcp` audience handling remains unchanged.

## Verification

```text
uv run --group dev ruff check src tests
uv run --group dev black --check src tests
uv run python -m unittest discover -s tests/unit -v  # 233 passed
```
