### PR TITLE
fix: mark Advisor tools as project-scoped

### DIFF
--- a/src/mcp_server_appwrite/catalog_policy.py
+++ b/src/mcp_server_appwrite/catalog_policy.py
@@ -127,6 +127,7 @@ API_KEY_EXCLUDED_METHODS: dict[str, frozenset[str]] = {
 # calls. API-key mode already has a fixed project on its configured client.
 PROJECT_CONTEXT_SERVICES: frozenset[str] = frozenset(
     {
+        "advisor",
         "databases",
         "documents_db",
         "embeddings",

--- a/src/mcp_server_appwrite/operator.py
+++ b/src/mcp_server_appwrite/operator.py
@@ -249,7 +249,7 @@ class Operator:
                                 "Appwrite project ID to act on (sent as X-Appwrite-Project). "
                                 "The connection authenticates against the Appwrite console, which "
                                 "can list your projects/organizations but holds no data — so "
-                                "project-scoped tools (databases, documents, vectors, users, "
+                                "project-scoped tools (Advisor, databases, documents, vectors, users, "
                                 "storage, functions, messaging, sites, usage, VCS, and WAF) "
                                 "require this. Search results identify each tool's context. Discover a project "
                                 "first, then pass its id. Omit for console/account-level tools."

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -1054,7 +1054,7 @@ def build_instructions(transport: str = "http") -> str:
     return (
         "You authenticate against the Appwrite console, which can list your "
         "organizations and projects but stores no project data itself. Project-scoped "
-        "tools (TablesDB, tables, users, storage, functions, messaging, sites) need a "
+        "tools (Advisor, TablesDB, tables, users, storage, functions, messaging, sites) need a "
         "target project: use appwrite_get_context first, then pass the selected "
         "project id as project_id to appwrite_call_tool. "
         "Organization-scoped console tools (e.g. creating a project) need organization_id. "

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -649,6 +649,19 @@ class ServerHelperTests(unittest.TestCase):
         self.assertEqual(len(manager_a.services), 39)
         self.assertEqual(len(manager_a.get_all_tools()), 992)
 
+    def test_advisor_tools_are_project_scoped(self):
+        manager = register_services(object(), profile=OAUTH_PROFILE)
+        advisor_tools = {
+            name: tool
+            for name, tool in manager.tools_registry.items()
+            if name.startswith("advisor_")
+        }
+
+        self.assertTrue(advisor_tools)
+        self.assertEqual(
+            {tool["context_scope"] for tool in advisor_tools.values()}, {"project"}
+        )
+
     def test_api_key_profile_only_advertises_server_capabilities(self):
         manager = register_services(object(), profile=API_KEY_PROFILE)
         service_names = {service.service_name for service in manager.services}


### PR DESCRIPTION
Advisor SDK methods call project resources under `/reports`, but the hidden catalog classified the service as `context=console`. Hosted calls therefore did not require a project and defaulted to the Console project.

```text
before: advisor_list_reports context=console
 after: advisor_list_reports context=project -> requires project_id
```

Add Advisor to the project-context policy, update hosted guidance, and assert that every generated Advisor tool carries project context.

This corrects MCP targeting, but production still has a separate downstream blocker: a fresh OAuth token advertises `project:reports.read`, while targeted `/reports` calls return `missing scopes (["reports.read"])`. That scope translation must be fixed in Appwrite Cloud before Advisor succeeds end to end.

## Verification

```text
uv run --group dev ruff check src tests
uv run --group dev black --check src tests
uv run --group dev pyright
uv run python -m unittest discover -s tests/unit -v  # 234 passed
```

Live production probe: `users_list` succeeded across all six accessible projects; `advisor_list_reports` reached each project's regional endpoint but consistently returned the downstream `reports.read` scope error.
