### PR TITLE
Return raw responses when SDK deserialization fails

### DIFF
--- a/src/mcp_server_appwrite/docs.py
+++ b/src/mcp_server_appwrite/docs.py
@@ -12,9 +12,13 @@ QUERIES_GUIDANCE = (
     "Each query is its own JSON string, e.g. "
     '{"method":"greaterThanEqual","attribute":"rating","values":[2]}. Filters '
     "take attribute and values: equal, notEqual, lessThan, lessThanEqual, "
-    "greaterThan, greaterThanEqual, between, startsWith, endsWith, contains, "
-    "search. isNull, isNotNull, orderAsc and orderDesc take attribute only. "
-    "limit, offset, cursorAfter and cursorBefore take values only. On list "
+    "greaterThan, greaterThanEqual, between, startsWith, endsWith and contains. "
+    "Free-text search can be passed in this array as "
+    '`{"method":"search","attribute":"search","values":["term"]}`. '
+    "The search attribute must have a full-text index; a listed filter attribute "
+    "is not necessarily searchable. Use the tool's top-level `search` parameter "
+    "instead when one is available. isNull, isNotNull, orderAsc and orderDesc "
+    "take attribute only. limit, offset, cursorAfter and cursorBefore take values only. On list "
     "endpoints a relationship returns only the related ID unless selected: "
     '{"method":"select","values":["*","author.*"]} expands it in the same call, '
     "avoiding one call per row."

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -859,6 +859,8 @@ def execute_registered_tool(
             project_id=target_project,
             organization_id=organization_id,
         )
+        if is_response_parse_error(exc):
+            return _format_response_parse_fallback(exc, name, prepared_arguments)
         raise RuntimeError(_format_appwrite_error(exc, tool_name=name)) from exc
     except Exception as exc:
         error_monitoring.capture_exception(
@@ -881,6 +883,8 @@ def execute_registered_tool(
             },
             transaction=(f"appwrite.{parsed['service_name']}.{parsed['action_verb']}"),
         )
+        if is_response_parse_error(exc):
+            return _format_response_parse_fallback(exc, name, prepared_arguments)
         raise
 
     return _format_tool_result(name, result, prepared_arguments)
@@ -973,6 +977,21 @@ def _format_tool_result(
         return [types.TextContent(type="text", text=_serialize_result(result))]
 
     return [types.TextContent(type="text", text=str(result))]
+
+
+def _format_response_parse_fallback(
+    exc: BaseException, tool_name: str, arguments: dict[str, Any]
+) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
+    """Return an upstream success even when the SDK response model is stale."""
+    return _format_tool_result(
+        tool_name,
+        {
+            "ok": True,
+            "data": {"raw": _parse_error_response(exc)},
+            "warning": "SDK deserialization failed",
+        },
+        arguments,
+    )
 
 
 def _format_appwrite_error(exc: AppwriteException, tool_name: str | None = None) -> str:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import io
+import json
 import os
 import sys
 import tempfile
@@ -963,6 +964,79 @@ class ServerHelperTests(unittest.TestCase):
         self.assertEqual(capture.call_args.kwargs["service"], "users")
         self.assertEqual(capture.call_args.kwargs["action"], "list")
         self.assertIsNone(capture.call_args.kwargs["project_id"])
+
+    def test_execute_registered_tool_returns_raw_success_on_sdk_parse_failure(self):
+        tool = types.Tool(
+            name="sites_list_logs",
+            description="List site logs.",
+            inputSchema={
+                "type": "object",
+                "properties": {"site_id": {"type": "string"}},
+                "required": ["site_id"],
+            },
+        )
+        manager = ToolManager()
+        manager.tools_registry = {
+            "sites_list_logs": {
+                "definition": tool,
+                "service_name": "sites",
+                "method_name": "list_logs",
+                "parameter_types": {"site_id": str},
+            }
+        }
+        executions = [
+            {
+                "$id": f"log-{status}",
+                "requestHeaders": [{"name": "x-request-id", "value": "req-1"}],
+                "responseHeaders": [{"name": "content-type", "value": "text/plain"}],
+                "responseStatusCode": status,
+                "status": "completed" if status < 500 else "failed",
+                "duration": status / 1000,
+                "logs": f"stdout-{status}",
+                "errors": f"stderr-{status}",
+            }
+            for status in (200, 400, 500)
+        ]
+        raw_response = {"total": len(executions), "executions": executions}
+
+        class SitesService:
+            def __init__(self, client):
+                pass
+
+            def list_logs(self, site_id):
+                raise AppwriteException(
+                    "Unable to parse response into ExecutionList: validation error",
+                    response=raw_response,
+                )
+
+        with (
+            patch.dict(server_module.SERVICE_CLASSES, {"sites": SitesService}),
+            patch.object(
+                server_module.error_monitoring, "capture_appwrite_exception"
+            ) as capture,
+        ):
+            content = execute_registered_tool(
+                manager,
+                "sites_list_logs",
+                {"site_id": "site-1"},
+                client=object(),
+            )
+
+        result = json.loads(content[0].text)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["warning"], "SDK deserialization failed")
+        self.assertEqual(result["data"]["raw"], raw_response)
+        for expected, actual in zip(executions, result["data"]["raw"]["executions"]):
+            self.assertEqual(actual["requestHeaders"], expected["requestHeaders"])
+            self.assertEqual(actual["responseHeaders"], expected["responseHeaders"])
+            self.assertEqual(
+                actual["responseStatusCode"], expected["responseStatusCode"]
+            )
+            self.assertEqual(actual["status"], expected["status"])
+            self.assertEqual(actual["duration"], expected["duration"])
+            self.assertEqual(actual["logs"], expected["logs"])
+            self.assertEqual(actual["errors"], expected["errors"])
+        capture.assert_called_once()
 
     def test_execute_registered_tool_passes_target_context_to_appwrite_capture(self):
         tool = types.Tool(

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -96,6 +96,8 @@ class ServiceSchemaTests(unittest.TestCase):
         # actionable part. It leads, because search output truncates.
         self.assertTrue(description.startswith(QUERIES_GUIDANCE))
         self.assertIn('{"method":"greaterThanEqual"', description)
+        self.assertIn('`{"method":"search"', description)
+        self.assertIn("must have a full-text index", description)
         self.assertIn("Query class provided by the SDK", description)
 
     def test_leaves_other_parameters_untouched(self):


### PR DESCRIPTION
## Description

Treat successful Appwrite responses as successful MCP results when the generated SDK cannot hydrate a stale response model. Preserve the raw body instead of returning an MCP tool error:

```json
{
  "ok": true,
  "data": { "raw": "..." },
  "warning": "SDK deserialization failed"
}
```

This fixes Sites log results with response fields newer than the SDK model. Query guidance now also documents the JSON wire format for full-text search and its index requirement.

## Testing

```text
uv run python -m unittest discover -s tests/unit -v
uv run --group dev ruff check src tests
uv run --group dev black --check src tests
uv run --group dev pyright
```

235 unit tests pass; lint, formatting, and type checks pass.
