### PR TITLE
chore(deploy): push image bumps to application-configuration

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,9 +15,10 @@ permissions:
 
 env:
   ENVIRONMENT: production
-  PROJECT: mcp
+  PROJECT: assets
+  APPLICATION: mcp
   DECLARATIVE_OWNER: appwrite-labs
-  DECLARATIVE_REPOSITORY: assets-applications
+  DECLARATIVE_REPOSITORY: application-configuration
   REGISTRY_GITHUB: ghcr.io
   REGISTRY_DOCKERHUB: docker.io
   IMAGE_NAME: appwrite/mcp
@@ -88,16 +89,16 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Update image tag
-        run: yq -i '.global.image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
+        run: yq -i '.global.image.tag = strenv(TAG)' ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
 
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
+          git add ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
           if git diff --cached --quiet; then
             echo "No changes to commit"
             exit 0
           fi
-          git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
+          git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.APPLICATION }} image tag to ${{ env.TAG }}"
           git push

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -16,9 +16,10 @@ permissions:
 
 env:
   ENVIRONMENT: staging
-  PROJECT: mcp
+  PROJECT: assets
+  APPLICATION: mcp
   DECLARATIVE_OWNER: appwrite-labs
-  DECLARATIVE_REPOSITORY: assets-applications
+  DECLARATIVE_REPOSITORY: application-configuration
   REGISTRY_GITHUB: ghcr.io
   REGISTRY_DOCKERHUB: docker.io
   IMAGE_NAME: appwrite/mcp
@@ -79,16 +80,16 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Update image tag
-        run: yq -i '.global.image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
+        run: yq -i '.global.image.tag = strenv(TAG)' ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
 
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
+          git add ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
           if git diff --cached --quiet; then
             echo "No changes to commit"
             exit 0
           fi
-          git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
+          git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.APPLICATION }} image tag to ${{ env.TAG }}"
           git push


### PR DESCRIPTION
## What

`mcp` moved out of [`assets-applications`](https://github.com/appwrite-labs/assets-applications) into [`application-configuration`](https://github.com/appwrite-labs/application-configuration) (appwrite-labs/application-configuration#12), which is laid out as `<project>/<env>/<app>` instead of `<env>/<app>`.

Affected workflows: production,staging.

```diff
-  PROJECT: mcp
+  PROJECT: assets
+  APPLICATION: mcp
-  DECLARATIVE_REPOSITORY: assets-applications
+  DECLARATIVE_REPOSITORY: application-configuration

-  ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
+  ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
```

`PROJECT` now names the project and `APPLICATION` the app, matching the `dns` workflows already deploying to that repo. The commit subject still names the app, so the bump commits read the same as before.

The declarative-deployment GitHub App is already installed on `application-configuration` — it is what the `dns` pipeline authenticates with.

## Merge order

**Last.** ArgoCD has to be reading the new repo first, otherwise a bump lands where nothing syncs from. Order: appwrite-labs/reusable-workflows#10 → appwrite-labs/application-configuration#12 → appwrite-labs/cluster-configuration-generator#158 (plus its generated PR into `cluster-configuration`) → this.