### PR TITLE
Release documentation index updates

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Optional release tag in vMAJOR.MINOR.PATCH format
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -22,7 +27,8 @@ env:
   REGISTRY_GITHUB: ghcr.io
   REGISTRY_DOCKERHUB: docker.io
   IMAGE_NAME: appwrite/mcp
-  TAG: ${{ github.event.release.tag_name || github.sha }}
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+  TAG: ${{ github.event.release.tag_name || inputs.tag || github.sha }}
 
 jobs:
   build:
@@ -48,9 +54,12 @@ jobs:
       - name: Derive package version
         id: package-version
         run: |
-          TAG="${{ github.event.release.tag_name || '' }}"
-          if [ -n "$TAG" ]; then
-            echo "package_version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          if [ -n "$RELEASE_TAG" ]; then
+            if ! echo "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "Release tag $RELEASE_TAG must match vMAJOR.MINOR.PATCH" >&2
+              exit 1
+            fi
+            echo "package_version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
           else
             echo "package_version=0.0.0+${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,15 @@ name: Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag in vMAJOR.MINOR.PATCH format
+        required: true
+        type: string
+
+env:
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
 
 jobs:
   publish:
@@ -28,7 +37,7 @@ jobs:
 
       - name: Derive release version
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$RELEASE_TAG"
           if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Release tag $TAG must match vMAJOR.MINOR.PATCH" >&2
             exit 1
@@ -66,7 +75,7 @@ jobs:
 
       - name: Render MCP Registry metadata
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$RELEASE_TAG"
           if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Release tag $TAG must match vMAJOR.MINOR.PATCH" >&2
             exit 1

--- a/.github/workflows/update-docs-index.yml
+++ b/.github/workflows/update-docs-index.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -43,11 +44,13 @@ jobs:
         run: uv run --group dev python scripts/build_docs_index.py
 
       - name: Commit updated index
+        id: commit
         run: |
           git add src/mcp_server_appwrite/data/docs_index.npz \
             src/mcp_server_appwrite/data/docs_index_meta.json
           if git diff --cached --quiet; then
             echo "Documentation index is already up to date"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -56,3 +59,36 @@ jobs:
           git commit -m "chore: refresh documentation search index"
           git pull --rebase origin main
           git push origin HEAD:main
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create patch release
+        id: release
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
+        run: |
+          LATEST_TAG="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
+          if [[ ! "$LATEST_TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Latest release tag $LATEST_TAG must match vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+
+          TAG="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
+          gh release create "$TAG" \
+            --target "$COMMIT_SHA" \
+            --title "$TAG" \
+            --notes "- Refresh the embedded Appwrite documentation index."
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # Events created with GITHUB_TOKEN do not start other workflows, so dispatch
+      # publishing and production explicitly for the newly created release tag.
+      - name: Publish and deploy release
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          gh workflow run publish.yml --ref "$TAG" -f tag="$TAG"
+          gh workflow run production.yml --ref "$TAG" -f tag="$TAG"


### PR DESCRIPTION
## Summary

- create the next patch release whenever the daily docs index changes
- dispatch package publishing and production deployment explicitly because releases created with `GITHUB_TOKEN` do not trigger follow-on workflows
- add validated release-tag inputs to the publish and production workflows

```text
docs changed → commit → patch release → publish + production
no changes    → no commit or release
```

## Test plan

- `actionlint .github/workflows/*.yml`
- parsed all workflow files with PyYAML
- verified `vMAJOR.MINOR.PATCH` derivation and validation paths
