### PR TITLE
fix: lead server instructions with capabilities so clients discover docs search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mcp-server-appwrite"
 dynamic = ["version"]
-description = "MCP (Model Context Protocol) server for Appwrite"
+description = "MCP server for Appwrite: manage projects and their databases, auth, storage, functions, messaging, and sites, and search the official Appwrite documentation"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [

--- a/server.template.json
+++ b/server.template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.appwrite/mcp",
-  "description": "MCP (Model Context Protocol) server for Appwrite",
+  "description": "MCP server for Appwrite: manage projects and their databases, auth, storage, functions, messaging, and sites, and search the official Appwrite documentation",
   "version": "__VERSION__",
   "repository": {
     "url": "https://github.com/appwrite/mcp",

--- a/src/mcp_server_appwrite/operator.py
+++ b/src/mcp_server_appwrite/operator.py
@@ -137,6 +137,10 @@ class Operator:
     def get_catalog_resource_uri(self) -> str:
         return CATALOG_URI
 
+    @property
+    def docs_enabled(self) -> bool:
+        return self._docs_search is not None
+
     def get_public_tools(self) -> list[types.Tool]:
         tools = [
             types.Tool(

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -1027,24 +1027,38 @@ def _format_response_parse_error(tool_name: str | None, response: Any = None) ->
     )
 
 
-def build_instructions(transport: str = "http") -> str:
+def build_instructions(transport: str = "http", *, docs_enabled: bool = True) -> str:
+    docs = (
+        "For questions about Appwrite concepts, products, features, or guides, "
+        "use appwrite_search_docs — it searches the official Appwrite "
+        "documentation and needs no project or credentials. "
+        if docs_enabled
+        else ""
+    )
+    capabilities = (
+        "This server covers the full Appwrite platform: it operates on Appwrite "
+        "resources (databases, auth/users, storage, functions, messaging, sites, "
+        "and more) via a searchable tool catalog"
+        + (" and answers Appwrite documentation questions" if docs_enabled else "")
+        + ". "
+    )
     result_handling = (
         "Large results are stored as resources; read the URI returned by the tool."
         if transport == "stdio"
         else "Hosted HTTP returns tool results inline, including images and other binary payloads."
     )
     common = (
+        f"{docs}"
         "Appwrite workflow: use appwrite_get_context to understand the current "
         "connection and available project resources, then use appwrite_search_tools "
         "and appwrite_call_tool for specific operations. "
         "Mutating hidden tools require confirm_write=true. "
-        "For questions about Appwrite concepts, products, or guides, use "
-        "appwrite_search_docs to search the documentation when available. "
         f"{result_handling}"
     )
 
     if transport == "stdio":
         return (
+            f"{capabilities}"
             "This local Appwrite MCP connection uses the API key, endpoint, and "
             "project configured in the server environment. Appwrite API calls target "
             "that configured APPWRITE_PROJECT_ID by default. "
@@ -1052,6 +1066,7 @@ def build_instructions(transport: str = "http") -> str:
         )
 
     return (
+        f"{capabilities}"
         "You authenticate against the Appwrite console, which can list your "
         "organizations and projects but stores no project data itself. Project-scoped "
         "tools (Advisor, TablesDB, tables, users, storage, functions, messaging, sites) need a "
@@ -1068,7 +1083,9 @@ def build_instructions(transport: str = "http") -> str:
 
 def build_mcp_server(operator: Operator, *, transport: str = "http") -> Server:
     _configure_uploads(transport)
-    instructions = build_instructions(transport)
+    instructions = build_instructions(
+        transport, docs_enabled=bool(getattr(operator, "docs_enabled", False))
+    )
     subscriptions = ListenHandler(InMemorySubscriptionBus())
 
     async def handle_list_tools(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -165,6 +165,25 @@ class ServerHelperTests(unittest.TestCase):
         self.assertIn("Large results are stored as resources", stdio)
         self.assertIn("returns tool results inline", http)
 
+    def test_build_instructions_lead_with_capabilities(self):
+        for transport in ("stdio", "http"):
+            instructions = build_instructions(transport)
+            self.assertTrue(
+                instructions.startswith(
+                    "This server covers the full Appwrite platform"
+                ),
+                instructions,
+            )
+
+    def test_build_instructions_state_docs_search_when_enabled(self):
+        for transport in ("stdio", "http"):
+            enabled = build_instructions(transport, docs_enabled=True)
+            disabled = build_instructions(transport, docs_enabled=False)
+            self.assertIn("appwrite_search_docs", enabled)
+            self.assertIn("documentation", enabled)
+            self.assertNotIn("when available", enabled)
+            self.assertNotIn("appwrite_search_docs", disabled)
+
     def test_build_mcp_server_supports_modern_subscriptions(self):
         server = build_mcp_server(Mock(), transport="http")
 


### PR DESCRIPTION
## Problem

MCP clients that summarize the server description (e.g. Claude Code's abbreviated server listing) were inferring that this server only manages Appwrite Console organizations/projects, and skipped `appwrite_search_docs` for Appwrite documentation questions — falling back to a browser instead. Observed in a real session: the client explicitly said it "incorrectly inferred its capabilities from the abbreviated server description".

Root cause: the hosted instructions open with console authentication mechanics ("You authenticate against the Appwrite console, which can list your organizations and projects…") and mention docs search only at the end, hedged with "when available".

## Fix

- `build_instructions` now opens with a capability summary covering both resource operations (databases, auth, storage, functions, messaging, sites) and documentation search, for both transports.
- The `appwrite_search_docs` guidance is stated prominently and unconditionally when the tool is actually wired in, and omitted entirely when it is not — driven by a new `Operator.docs_enabled` property instead of the static "when available" hedge.
- Registry (`server.template.json`) and package (`pyproject.toml`) descriptions updated to state the full capability range, since clients cache these as the server description.

## Tests

Added regression tests asserting instructions lead with the capability summary and that `appwrite_search_docs` appears (un-hedged) when docs are enabled and disappears when disabled. Ruff, black, pyright, and all 236 unit tests pass locally.