### PR TITLE
fix: keep registry description within the 100-char MCP Registry limit

### DIFF
--- a/server.template.json
+++ b/server.template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.appwrite/mcp",
-  "description": "MCP server for Appwrite: manage projects and their databases, auth, storage, functions, messaging, and sites, and search the official Appwrite documentation",
+  "description": "Manage Appwrite projects, databases, auth, storage, functions, and messaging; search Appwrite docs",
   "version": "__VERSION__",
   "repository": {
     "url": "https://github.com/appwrite/mcp",

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -34,6 +34,13 @@ class ServerVersionTests(unittest.TestCase):
             self.assertEqual(constants._resolve_server_version(), "0.0.0+unknown")
 
 
+class ServerTemplateTests(unittest.TestCase):
+    def test_description_fits_mcp_registry_limit(self):
+        template_path = Path(__file__).parents[2] / "server.template.json"
+        template = json.loads(template_path.read_text())
+        self.assertLessEqual(len(template["description"]), 100)
+
+
 class RenderServerMetadataTests(unittest.TestCase):
     def test_render_server_metadata_sets_all_release_versions(self):
         module = _load_render_module()


### PR DESCRIPTION
The v0.8.45 `Publish` workflow failed: the MCP Registry rejected `server.json` with a 422 (`expected length <= 100` on `body.description`) after #107 expanded the description to 155 characters. Production deployment succeeded, so only the registry publish is affected.

This shortens the template description to 98 characters while keeping the capability summary (resource management + docs search), and adds a regression test asserting `server.template.json`'s description stays within the registry's 100-character limit.

After merge, a new patch release (v0.8.46) will re-run the publish.