### PR TITLE
Update console SDK to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "anyio>=4.0.0",
-    "appwrite-console>=0.5.0,<0.6",
+    "appwrite-console>=0.6.0,<0.7",
     "docstring-parser>=0.16",
     "mcp[cli]>=2,<3",
     "python-dotenv>=1.0.1",

--- a/tests/integration/test_avatars.py
+++ b/tests/integration/test_avatars.py
@@ -8,5 +8,6 @@ class AvatarsIntegrationTests(LiveIntegrationTestCase):
 
         runner.call("avatars_get_browser", {"code": "ch"})
         runner.call("avatars_get_initials", {"name": "MCP Smoke"})
+        runner.call("avatars_get_photo", {"name": "MCP Smoke"})
 
         self.assert_no_unexpected_errors(runner)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -666,7 +666,53 @@ class ServerHelperTests(unittest.TestCase):
             set(SERVICE_CLASSES),
         )
         self.assertEqual(len(manager_a.services), 39)
-        self.assertEqual(len(manager_a.get_all_tools()), 992)
+        self.assertEqual(len(manager_a.get_all_tools()), 994)
+
+    def test_console_sdk_0_6_surface(self):
+        manager = register_services(object(), profile=OAUTH_PROFILE)
+        tools = manager.tools_registry
+
+        self.assertIn("avatars_get_photo", tools)
+        self.assertIn("project_update_o_auth2_hugging_face", tools)
+
+        site_scopes = tools["sites_create"]["definition"].input_schema["properties"][
+            "scopes"
+        ]
+        self.assertEqual(site_scopes["type"], "array")
+        self.assertNotIn("dedicateddatabases.execute", site_scopes["items"]["enum"])
+
+        for tool_name in ("usage_list_events", "usage_list_gauges"):
+            metrics = tools[tool_name]["definition"].input_schema["properties"][
+                "metrics"
+            ]
+            self.assertEqual(metrics["type"], "array")
+            self.assertEqual(metrics["items"], {"type": "string"})
+            self.assertNotIn("enum", metrics["items"])
+
+        create_rate_limit = tools["waf_create_rate_limit_rule"][
+            "definition"
+        ].input_schema["properties"]
+        self.assertEqual(create_rate_limit["strategy"]["type"], "string")
+        self.assertEqual(create_rate_limit["max_bucket_size"]["type"], "number")
+        update_rate_limit = tools["waf_update_rate_limit_rule"][
+            "definition"
+        ].input_schema["properties"]
+        self.assertEqual(update_rate_limit["max_bucket_size"]["type"], "number")
+
+        addon = tools["organizations_get_addon_price"]["definition"].input_schema[
+            "properties"
+        ]["addon"]
+        self.assertEqual(addon["type"], "string")
+        self.assertIn("backup_recovery", addon["enum"])
+
+        runtime = tools["functions_create"]["definition"].input_schema["properties"][
+            "runtime"
+        ]
+        self.assertIn("bun-1.4", runtime["enum"])
+        build_runtime = tools["sites_create"]["definition"].input_schema["properties"][
+            "build_runtime"
+        ]
+        self.assertIn("bun-1.4", build_runtime["enum"])
 
     def test_advisor_tools_are_project_scoped(self):
         manager = register_services(object(), profile=OAUTH_PROFILE)
@@ -687,7 +733,9 @@ class ServerHelperTests(unittest.TestCase):
         tool_names = {tool.name for tool in manager.get_all_tools()}
 
         self.assertEqual(len(manager.services), 26)
-        self.assertEqual(len(tool_names), 650)
+        self.assertEqual(len(tool_names), 652)
+        self.assertIn("avatars_get_photo", tool_names)
+        self.assertIn("project_update_o_auth2_hugging_face", tool_names)
         self.assertIn("documents_db_list", tool_names)
         self.assertIn("vectors_db_list", tool_names)
         self.assertIn("embeddings_create_text_embeddings", tool_names)

--- a/uv.lock
+++ b/uv.lock
@@ -39,15 +39,15 @@ wheels = [
 
 [[package]]
 name = "appwrite-console"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/8a/e03a30411b33431ead5b68d1101e09e8992d8295aaf1e550fafd11aa84e3/appwrite_console-0.5.0.tar.gz", hash = "sha256:e8a1edb3cbc47fea6aacc7df124e20e3fb1facdbfbb5ed8f2594ddfde56190b5", size = 302041, upload-time = "2026-08-12T13:33:28.932Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/4e/008876bbd6ee5d41663a7a190b5ff07f3ef135ec57341fc33e18dcdbf625/appwrite_console-0.6.0.tar.gz", hash = "sha256:c406909d319d4e91463d240a3fcd9f91589fea28cb460431b1e7b4b71d6b31f8", size = 306923, upload-time = "2026-08-27T08:24:24.81Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/47/185b10c036d9dfce3c23eae97b873598416748cce24f6b8605800ad70b0a/appwrite_console-0.5.0-py3-none-any.whl", hash = "sha256:07d11dfaa8989bcfd0335a254e7e9296a4dff8fb3beb3e9d061719ccd7b5288e", size = 530460, upload-time = "2026-08-12T13:33:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/25/30/84db4c5096620ac1db9f1c6602ba49a972ce369f36f3bda0285953cab84e/appwrite_console-0.6.0-py3-none-any.whl", hash = "sha256:ae90fb5d7d89071739536d4cab48ab4563286dfdefebf803b5a67717a593ac3b", size = 536203, upload-time = "2026-08-27T08:24:23.288Z" },
 ]
 
 [[package]]
@@ -695,7 +695,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0.0" },
-    { name = "appwrite-console", specifier = ">=0.5.0,<0.6" },
+    { name = "appwrite-console", specifier = ">=0.6.0,<0.7" },
     { name = "argon2-cffi", marker = "extra == 'integration'", specifier = ">=23.1.0" },
     { name = "bcrypt", marker = "extra == 'integration'", specifier = ">=4.1.2" },
     { name = "docstring-parser", specifier = ">=0.16" },


### PR DESCRIPTION
## Summary

- update `appwrite-console` from 0.5.x to 0.6.x and refresh the lockfile
- update catalog counts for the new avatar photo and Hugging Face OAuth tools
- cover the 0.6.0 schema changes for site scopes, usage metrics, WAF rate limits, addons, and Bun 1.4
- exercise `avatars_get_photo` in the live integration smoke test

## Validation

- `uv run --group dev ruff check src tests`
- `uv run --group dev black --check src tests`
- `uv run --group dev pyright`
- `uv run python -m unittest discover -s tests/unit -v` (238 tests)
- `docker build -t appwrite-mcp:sdk-0.6.0 .`
