### PR TITLE
fix: reduce expected Sentry noise

### DIFF
--- a/src/mcp_server_appwrite/error_monitoring.py
+++ b/src/mcp_server_appwrite/error_monitoring.py
@@ -30,6 +30,14 @@ _SENSITIVE_KEYS = {
     "x_appwrite_key",
 }
 
+_IGNORED_LOGGER_PREFIXES = ("opentelemetry.exporter.otlp.",)
+_IGNORED_LOG_MESSAGES = {
+    (
+        "uvicorn.error",
+        "ASGI callable returned without completing response.",
+    ),
+}
+
 
 def _log(message: str) -> None:
     print(f"[appwrite-mcp][sentry] {message}", file=sys.stderr, flush=True)
@@ -161,11 +169,32 @@ def capture_appwrite_exception(
 def _should_capture(exc: BaseException) -> bool:
     if _already_captured(exc):
         return False
-    if isinstance(exc, ValueError):
+
+    category = classify_tool_error(exc)
+    if category in {"write_confirmation", "appwrite_4xx"}:
         return False
-    if classify_tool_error(exc) in {"write_confirmation", "appwrite_4xx"}:
+    # Pydantic validation errors are ValueError subclasses, but SDK response
+    # validation is actionable model drift and must remain visible.
+    if category != "sdk_validation" and _find_exception(exc, ValueError) is not None:
+        return False
+    if _find_expected_disconnect(exc) is not None:
         return False
     return True
+
+
+def _find_expected_disconnect(exc: BaseException) -> BaseException | None:
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        error_type = type(current)
+        if (
+            error_type.__name__ == "ClientDisconnect"
+            and error_type.__module__.startswith("starlette.")
+        ):
+            return current
+        current = current.__cause__ or current.__context__
+    return None
 
 
 def _find_appwrite_exception(exc: BaseException) -> AppwriteException | None:
@@ -210,7 +239,29 @@ def _before_send(event: Any, hint: Any) -> Any:
         exc = exc_info[1]
         if isinstance(exc, BaseException) and not _should_capture(exc):
             return None
+    if _is_ignored_log_event(event):
+        return None
     return _normalize_transaction(_sanitize(event))
+
+
+def _is_ignored_log_event(event: Any) -> bool:
+    """Drop noisy infrastructure logs that have no exception to classify."""
+    if not isinstance(event, dict):
+        return False
+
+    tags = _event_tags(event)
+    raw_logger = event.get("logger") or tags.get("logger")
+    logger = str(raw_logger) if raw_logger else ""
+    if logger.startswith(_IGNORED_LOGGER_PREFIXES):
+        return True
+
+    logentry = event.get("logentry")
+    message = logentry.get("formatted") if isinstance(logentry, dict) else None
+    if not isinstance(message, str):
+        raw_message = event.get("message")
+        message = raw_message if isinstance(raw_message, str) else ""
+
+    return (logger, message) in _IGNORED_LOG_MESSAGES
 
 
 def _normalize_transaction(event: Any) -> Any:

--- a/tests/unit/test_error_monitoring.py
+++ b/tests/unit/test_error_monitoring.py
@@ -3,6 +3,8 @@ import unittest
 from unittest.mock import patch
 
 from appwrite_console.exception import AppwriteException
+from pydantic import BaseModel, ValidationError
+from starlette.requests import ClientDisconnect
 
 from mcp_server_appwrite import error_monitoring
 from mcp_server_appwrite.error_classification import WriteConfirmationRequired
@@ -53,31 +55,40 @@ class ErrorMonitoringTests(unittest.TestCase):
         self.assertFalse(captured)
         capture.assert_not_called()
 
-    def test_wrapped_value_errors_are_captured(self):
+    def test_wrapped_value_errors_are_not_captured(self):
         error_monitoring._enabled = True
 
-        class FakeScope:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                return False
-
-            def set_tag(self, key, value):
-                pass
-
-        scope = FakeScope()
         with patch("sentry_sdk.capture_exception") as capture:
-            with patch("sentry_sdk.new_scope", return_value=scope):
-                try:
-                    raise ValueError("bad input")
-                except ValueError as exc:
-                    wrapped = RuntimeError("wrapped")
-                    wrapped.__cause__ = exc
-                    captured = error_monitoring.capture_exception(wrapped)
+            try:
+                raise ValueError("bad input")
+            except ValueError as exc:
+                wrapped = RuntimeError("wrapped")
+                wrapped.__cause__ = exc
+                captured = error_monitoring.capture_exception(wrapped)
 
-        self.assertTrue(captured)
-        capture.assert_called_once_with(wrapped)
+        self.assertFalse(captured)
+        capture.assert_not_called()
+
+    def test_wrapped_sdk_validation_errors_are_captured(self):
+        class Payload(BaseModel):
+            required: str
+
+        try:
+            Payload.model_validate({})
+        except ValidationError as exc:
+            wrapped = RuntimeError("wrapped")
+            wrapped.__cause__ = exc
+
+        self.assertTrue(error_monitoring._should_capture(wrapped))
+
+    def test_client_disconnects_are_not_captured(self):
+        error_monitoring._enabled = True
+
+        with patch("sentry_sdk.capture_exception") as capture:
+            captured = error_monitoring.capture_exception(ClientDisconnect())
+
+        self.assertFalse(captured)
+        capture.assert_not_called()
 
     def test_appwrite_4xx_errors_are_not_captured(self):
         error_monitoring._enabled = True
@@ -265,6 +276,32 @@ class ErrorMonitoringTests(unittest.TestCase):
                 {"event_id": "1"}, {"exc_info": (RuntimeError, wrapped, None)}
             )
         )
+
+    def test_before_send_drops_otel_exporter_logs(self):
+        event = {
+            "logger": "opentelemetry.exporter.otlp.proto.http.metric_exporter",
+            "logentry": {"formatted": "Failed to export metrics batch"},
+        }
+
+        self.assertIsNone(error_monitoring._before_send(event, {}))
+
+    def test_before_send_drops_incomplete_disconnect_responses(self):
+        event = {
+            "tags": [["logger", "uvicorn.error"]],
+            "logentry": {
+                "formatted": "ASGI callable returned without completing response."
+            },
+        }
+
+        self.assertIsNone(error_monitoring._before_send(event, {}))
+
+    def test_before_send_keeps_other_uvicorn_errors(self):
+        event = {
+            "logger": "uvicorn.error",
+            "logentry": {"formatted": "Unexpected server failure"},
+        }
+
+        self.assertEqual(error_monitoring._before_send(event, {}), event)
 
     def test_before_send_normalizes_mcp_tool_call_transaction(self):
         event = {


### PR DESCRIPTION
## What does this PR do?

Filters expected failures and infrastructure log noise before they are sent to Sentry:

- drops `ClientDisconnect` exceptions from short-lived MCP HTTP clients
- drops wrapped input `ValueError` chains while preserving actionable SDK/Pydantic response validation errors
- drops OTLP exporter logs, which belong in collector/telemetry monitoring rather than application error tracking
- drops Uvicorn's expected `ASGI callable returned without completing response` message without suppressing other Uvicorn errors

This targets the recurring MCP-6, MCP-14/MCP-G, MCP-S, and wrapped invalid-input noise seen in the production Sentry audit.

## How was this tested?

- `uv run --group dev ruff check src tests`
- `uv run --group dev black --check src tests`
- `uv run --group dev pyright`
- `uv run python -m unittest discover -s tests/unit -v` (243 tests)
