### PR TITLE
feat: summarize documentation changes in the daily refresh release

### DIFF
--- a/.github/workflows/update-docs-index.yml
+++ b/.github/workflows/update-docs-index.yml
@@ -41,21 +41,38 @@ jobs:
       - name: Rebuild documentation index
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DOCS_REPORT_FILE: ${{ runner.temp }}/docs_report.json
         run: uv run --group dev python scripts/build_docs_index.py
+
+      - name: Summarize documentation changes
+        id: notes
+        env:
+          REPORT: ${{ runner.temp }}/docs_report.json
+          NOTES: ${{ runner.temp }}/docs_notes.md
+        run: |
+          uv run --group dev python scripts/docs_release_notes.py "$REPORT" "$NOTES"
+          echo "file=$NOTES" >> "$GITHUB_OUTPUT"
 
       - name: Commit updated index
         id: commit
+        env:
+          NOTES: ${{ steps.notes.outputs.file }}
         run: |
           git add src/mcp_server_appwrite/data/docs_index.npz
           if git diff --cached --quiet; then
             echo "Documentation index is already up to date"
             echo "changed=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Documentation index"
+              echo
+              echo "No changes since the last refresh. Release skipped."
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore: refresh documentation search index"
+          git commit -m "chore: refresh documentation search index" -m "$(cat "$NOTES")"
           git pull --rebase origin main
           git push origin HEAD:main
           echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -67,6 +84,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
+          NOTES: ${{ steps.notes.outputs.file }}
         run: |
           LATEST_TAG="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
           if [[ ! "$LATEST_TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
@@ -78,8 +96,15 @@ jobs:
           gh release create "$TAG" \
             --target "$COMMIT_SHA" \
             --title "$TAG" \
-            --notes "- Refresh the embedded Appwrite documentation index."
+            --notes-file "$NOTES"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Documentation index"
+            echo
+            echo "Released [$TAG](https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG)."
+            echo
+            cat "$NOTES"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # Events created with GITHUB_TOKEN do not start other workflows, so dispatch
       # publishing and production explicitly for the newly created release tag.

--- a/docs/documentation-search.md
+++ b/docs/documentation-search.md
@@ -48,3 +48,13 @@ removed pages, and can write the same report as JSON. Optional build env vars:
 | `DOCS_ORIGIN` | `https://appwrite.io` | Site to fetch the docs from (for example a staging deployment). |
 | `DOCS_EMBED_BATCH` | `100` | Embedding batch size. |
 | `DOCS_REPORT_FILE` | — | Write the JSON build report (page changes, chunks embedded vs reused) here. |
+| `DOCS_MIN_PAGES` | `400` | Abort when fewer pages are fetched, so a broken site or export cannot ship a gutted index. |
+
+## Daily refresh
+
+`.github/workflows/update-docs-index.yml` rebuilds the index every day. When the
+artifact is unchanged the job writes "No changes" to its summary and stops. When
+it changed, the job commits the artifact, renders the build report with
+`scripts/docs_release_notes.py` into release notes listing the added, updated,
+and removed pages with links, publishes a patch release with those notes, and
+dispatches the publish and production workflows.

--- a/scripts/build_docs_index.py
+++ b/scripts/build_docs_index.py
@@ -24,6 +24,9 @@ Env vars:
     DOCS_EMBED_BATCH      embedding batch size (default 100).
     DOCS_REPORT_FILE      optional path to write the JSON build report (page changes,
                           chunks embedded vs reused) for the refresh workflow.
+    DOCS_MIN_PAGES        abort when fewer pages are fetched (default 400). Guards
+                          against shipping a gutted index when the site or its
+                          exports are broken.
 """
 
 from __future__ import annotations
@@ -41,6 +44,7 @@ from mcp_server_appwrite.docs_index import build_index
 from mcp_server_appwrite.docs_source import DEFAULT_ORIGIN, fetch_pages
 
 EMBED_DIMENSION = 1536
+DEFAULT_MIN_PAGES = 400
 
 
 def embed_texts(client: OpenAI, texts: list[str], batch_size: int) -> np.ndarray:
@@ -73,12 +77,17 @@ def main() -> int:
     origin = os.getenv("DOCS_ORIGIN", DEFAULT_ORIGIN).rstrip("/")
     batch_size = int(os.getenv("DOCS_EMBED_BATCH", "100"))
     report_file = os.getenv("DOCS_REPORT_FILE")
+    min_pages = int(os.getenv("DOCS_MIN_PAGES", str(DEFAULT_MIN_PAGES)))
     client = OpenAI()
 
     print(f"Fetching documentation from {origin} ...")
     pages, skipped = asyncio.run(fetch_pages(origin))
-    if not pages:
-        print("No documentation pages fetched; aborting", file=sys.stderr)
+    if len(pages) < min_pages:
+        print(
+            f"Only {len(pages)} documentation pages fetched (minimum {min_pages}); "
+            "refusing to build a gutted index",
+            file=sys.stderr,
+        )
         return 1
     print(f"Fetched {len(pages)} pages, skipped {len(skipped)} unpublished")
     for path in skipped:

--- a/scripts/docs_release_notes.py
+++ b/scripts/docs_release_notes.py
@@ -1,0 +1,61 @@
+"""Turn a docs index build report into release notes for the refresh workflow.
+
+Reads the JSON written by ``scripts/build_docs_index.py`` (``DOCS_REPORT_FILE``)
+and writes Markdown listing the added, updated, and removed pages with links to
+appwrite.io. The same text becomes the GitHub release body and the job summary.
+
+    uv run python scripts/docs_release_notes.py report.json notes.md
+
+Exit status is 0 in every case; the workflow decides whether to release from
+the committed diff, not from this script.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from mcp_server_appwrite.docs_source import DEFAULT_ORIGIN
+
+SECTIONS = (("added", "Added"), ("changed", "Updated"), ("removed", "Removed"))
+
+
+def render(report: dict[str, Any], origin: str = DEFAULT_ORIGIN) -> str:
+    changes = report.get("changes", {})
+    counts = {key: len(changes.get(key, [])) for key, _ in SECTIONS}
+    lines = [
+        "Refresh the embedded Appwrite documentation index.",
+        "",
+        f"{report['pages']} pages, {report['chunks']} chunks "
+        f"({report['chunks_embedded']} embedded, {report['chunks_reused']} reused).",
+        "",
+    ]
+    if not any(counts.values()):
+        lines.append("No documentation pages were added, updated, or removed.")
+        return "\n".join(lines) + "\n"
+    for key, heading in SECTIONS:
+        pages = changes.get(key, [])
+        if not pages:
+            continue
+        lines.append(f"### {heading} ({len(pages)})")
+        lines.append("")
+        for page in pages:
+            title = page.get("title") or page["path"]
+            lines.append(f"- [{title}]({origin}/{page['path']})")
+        lines.append("")
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print("usage: docs_release_notes.py <report.json> <notes.md>", file=sys.stderr)
+        return 2
+    report = json.loads(Path(argv[1]).read_text(encoding="utf-8"))
+    Path(argv[2]).write_text(render(report), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/docs_release_notes.py
+++ b/scripts/docs_release_notes.py
@@ -13,13 +13,16 @@ the committed diff, not from this script.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from mcp_server_appwrite.docs_source import DEFAULT_ORIGIN
 
 SECTIONS = (("added", "Added"), ("changed", "Updated"), ("removed", "Removed"))
+_MARKDOWN_SPECIAL = re.compile(r"([\\`*_\[\]<>#|])")
 
 
 def render(report: dict[str, Any], origin: str = DEFAULT_ORIGIN) -> str:
@@ -43,9 +46,16 @@ def render(report: dict[str, Any], origin: str = DEFAULT_ORIGIN) -> str:
         lines.append("")
         for page in pages:
             title = page.get("title") or page["path"]
-            lines.append(f"- [{title}]({origin}/{page['path']})")
+            lines.append(
+                f"- [{escape(title)}]({origin}/{quote(page['path'], safe='/')})"
+            )
         lines.append("")
     return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def escape(text: str) -> str:
+    """Neutralize Markdown syntax in page titles so links render as written."""
+    return _MARKDOWN_SPECIAL.sub(r"\\\1", text.replace("\n", " "))
 
 
 def main(argv: list[str]) -> int:


### PR DESCRIPTION
## Why

The daily docs refresh released with a fixed one-line note and gave no indication of what changed, and a quiet run left no trace of why it stopped. With #114 making the artifact deterministic, the build now knows exactly which pages were added, updated, or removed, so the release can say so.

## What

- `scripts/build_docs_index.py` writes its JSON report to `DOCS_REPORT_FILE` in the workflow, and refuses to build when fewer than `DOCS_MIN_PAGES` (default 400) pages come back, so a broken site or export cannot ship a gutted index.
- New `scripts/docs_release_notes.py` renders that report into Markdown: page and chunk counts, then Added, Updated, and Removed sections linking each page on appwrite.io.
- `update-docs-index.yml` uses the rendered notes as the release body and the commit body, and writes them to the job summary. When the artifact is unchanged the summary says "No changes since the last refresh. Release skipped." and the job exits before committing.

## What it produces

Release notes and job summary for a day with changes:

```markdown
Refresh the embedded Appwrite documentation index.

588 pages, 5870 chunks (24 embedded, 5846 reused).

### Added (2)

- [Passkeys](https://appwrite.io/docs/products/auth/passkeys)
- [docs/products/sites/redirects](https://appwrite.io/docs/products/sites/redirects)

### Updated (1)

- [MySQL](https://appwrite.io/docs/products/databases/mysql)

### Removed (1)

- [WAF](https://appwrite.io/docs/products/network/waf)
```

Job summary on a quiet day (no commit, no release, no deploy):

```markdown
## Documentation index

No changes since the last refresh. Release skipped.
```

Guard output when the site is broken (job fails, artifact untouched):

```
Only 586 documentation pages fetched (minimum 100000); refusing to build a gutted index
```

## Verification

- Notes script run on a synthetic report with all three change kinds and on today's real quiet-day report; output above.
- Guard exercised with `DOCS_MIN_PAGES=100000`: exit 1, no artifact written.
- Workflow passes `actionlint`.
- ruff, black, pyright, unit tests clean.