### PR TITLE
fix: validate required SDK tool arguments before execution

### DIFF
--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -781,6 +781,14 @@ def _normalize_argument_keys(
 def _validate_argument_keys(
     tool_name: str, tool_info: dict, arguments: dict[str, Any]
 ) -> None:
+    definition = tool_info.get("definition")
+    required = definition.input_schema.get("required", []) if definition else []
+    missing_names = sorted(name for name in required if name not in arguments)
+    if missing_names:
+        raise ValueError(
+            f"Missing required arguments for {tool_name}: {', '.join(missing_names)}."
+        )
+
     expected_names = _expected_argument_names(tool_info)
     if not expected_names:
         return

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -16,7 +16,6 @@ from appwrite_console.enums.browser import Browser
 from appwrite_console.exception import AppwriteException
 from appwrite_console.input_file import InputFile
 from appwrite_console.models.row_list import RowList
-from requests import Response
 
 from mcp_server_appwrite import server as server_module
 from mcp_server_appwrite.catalog_policy import API_KEY_PROFILE, OAUTH_PROFILE
@@ -451,15 +450,13 @@ class ServerHelperTests(unittest.TestCase):
         server = build_mcp_server(build_operator(manager, client), transport="stdio")
         entry = server.get_request_handler("tools/call")
         self.assertIsNotNone(entry)
-        arguments = {"functionId": "function-id", "key": "GREETING", "value": "hello"}
 
-        with patch("appwrite_console.client.requests.request") as request:
-            with self.assertRaises(ValueError) as error:
-                execute_registered_tool(
-                    manager, "functions_create_variable", arguments, client=client
-                )
-            request.assert_not_called()
-        self.assertIn("variable_id", str(error.exception))
+        class FunctionsService:
+            def __init__(self, client):
+                pass
+
+            def create_variable(self, **arguments):
+                return {}
 
         async def run_check():
             ctx = Mock()
@@ -471,62 +468,74 @@ class ServerHelperTests(unittest.TestCase):
                 arguments={
                     "tool_name": "functions_create_variable",
                     "confirm_write": True,
-                    "arguments": arguments,
+                    "arguments": {
+                        "functionId": "function-id",
+                        "key": "GREETING",
+                        "value": "hello",
+                    },
                 },
             )
-            with patch("appwrite_console.client.requests.request") as request:
-                result = await entry.handler(ctx, params)
+            result = await entry.handler(ctx, params)
 
             self.assertTrue(result.is_error)
             self.assertIn("functions_create_variable", result.content[0].text)
             self.assertIn("variable_id", result.content[0].text)
-            request.assert_not_called()
 
-        asyncio.run(run_check())
+        with patch.dict(server_module.SERVICE_CLASSES, {"functions": FunctionsService}):
+            asyncio.run(run_check())
 
-    def test_execute_sdk_tool_preserves_required_arguments_and_optional_defaults(self):
+    def test_call_tool_preserves_required_arguments_and_optional_defaults(self):
         client = build_introspection_client()
         manager = register_services(client, profile=API_KEY_PROFILE)
-        response = Response()
-        response.status_code = 201
-        response.headers["Content-Type"] = "application/json"
-        response._content = json.dumps(
-            {
-                "$id": "variable-id",
-                "$createdAt": "2026-09-10T00:00:00.000+00:00",
-                "$updatedAt": "2026-09-10T00:00:00.000+00:00",
-                "key": "GREETING",
-                "value": "",
-                "secret": False,
-                "resourceType": "function",
-                "resourceId": "function-id",
-            }
-        ).encode()
+        server = build_mcp_server(build_operator(manager, client), transport="stdio")
+        entry = server.get_request_handler("tools/call")
+        self.assertIsNotNone(entry)
 
-        with patch(
-            "appwrite_console.client.requests.request", return_value=response
-        ) as request:
-            result = execute_registered_tool(
-                manager,
-                "functions_create_variable",
-                {
-                    "functionId": "function-id",
-                    "variableId": "variable-id",
-                    "key": "GREETING",
-                    "value": "",
+        class FunctionsService:
+            def __init__(self, client):
+                pass
+
+            def create_variable(
+                self, function_id, variable_id, key, value, secret=False
+            ):
+                return {
+                    "$id": variable_id,
+                    "resourceId": function_id,
+                    "key": key,
+                    "value": value,
+                    "secret": secret,
+                }
+
+        async def run_check():
+            ctx = Mock()
+            ctx.protocol_version = "2026-07-28"
+            ctx.meta = None
+            ctx.session.client_params = None
+            params = types.CallToolRequestParams(
+                name="appwrite_call_tool",
+                arguments={
+                    "tool_name": "functions_create_variable",
+                    "confirm_write": True,
+                    "arguments": {
+                        "functionId": "function-id",
+                        "variableId": "variable-id",
+                        "key": "GREETING",
+                        "value": "",
+                    },
                 },
-                client=client,
             )
+            result = await entry.handler(ctx, params)
 
-        request.assert_called_once()
-        self.assertTrue(
-            request.call_args.kwargs["url"].endswith("/functions/function-id/variables")
-        )
-        self.assertEqual(
-            json.loads(request.call_args.kwargs["data"]),
-            {"variableId": "variable-id", "key": "GREETING", "value": ""},
-        )
-        self.assertEqual(json.loads(result[0].text)["$id"], "variable-id")
+            self.assertFalse(result.is_error)
+            variable = json.loads(result.content[0].text)
+            self.assertEqual(variable["$id"], "variable-id")
+            self.assertEqual(variable["resourceId"], "function-id")
+            self.assertEqual(variable["key"], "GREETING")
+            self.assertEqual(variable["value"], "")
+            self.assertFalse(variable["secret"])
+
+        with patch.dict(server_module.SERVICE_CLASSES, {"functions": FunctionsService}):
+            asyncio.run(run_check())
 
     def test_format_tool_result_serializes_json(self):
         result = _format_tool_result(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -16,6 +16,7 @@ from appwrite_console.enums.browser import Browser
 from appwrite_console.exception import AppwriteException
 from appwrite_console.input_file import InputFile
 from appwrite_console.models.row_list import RowList
+from requests import Response
 
 from mcp_server_appwrite import server as server_module
 from mcp_server_appwrite.catalog_policy import API_KEY_PROFILE, OAUTH_PROFILE
@@ -443,6 +444,89 @@ class ServerHelperTests(unittest.TestCase):
                     "maximumFileSize": 10_485_760,
                 },
             )
+
+    def test_call_tool_reports_missing_sdk_arguments_before_execution(self):
+        client = build_introspection_client()
+        manager = register_services(client, profile=API_KEY_PROFILE)
+        server = build_mcp_server(build_operator(manager, client), transport="stdio")
+        entry = server.get_request_handler("tools/call")
+        self.assertIsNotNone(entry)
+        arguments = {"functionId": "function-id", "key": "GREETING", "value": "hello"}
+
+        with patch("appwrite_console.client.requests.request") as request:
+            with self.assertRaises(ValueError) as error:
+                execute_registered_tool(
+                    manager, "functions_create_variable", arguments, client=client
+                )
+            request.assert_not_called()
+        self.assertIn("variable_id", str(error.exception))
+
+        async def run_check():
+            ctx = Mock()
+            ctx.protocol_version = "2026-07-28"
+            ctx.meta = None
+            ctx.session.client_params = None
+            params = types.CallToolRequestParams(
+                name="appwrite_call_tool",
+                arguments={
+                    "tool_name": "functions_create_variable",
+                    "confirm_write": True,
+                    "arguments": arguments,
+                },
+            )
+            with patch("appwrite_console.client.requests.request") as request:
+                result = await entry.handler(ctx, params)
+
+            self.assertTrue(result.is_error)
+            self.assertIn("functions_create_variable", result.content[0].text)
+            self.assertIn("variable_id", result.content[0].text)
+            request.assert_not_called()
+
+        asyncio.run(run_check())
+
+    def test_execute_sdk_tool_preserves_required_arguments_and_optional_defaults(self):
+        client = build_introspection_client()
+        manager = register_services(client, profile=API_KEY_PROFILE)
+        response = Response()
+        response.status_code = 201
+        response.headers["Content-Type"] = "application/json"
+        response._content = json.dumps(
+            {
+                "$id": "variable-id",
+                "$createdAt": "2026-09-10T00:00:00.000+00:00",
+                "$updatedAt": "2026-09-10T00:00:00.000+00:00",
+                "key": "GREETING",
+                "value": "",
+                "secret": False,
+                "resourceType": "function",
+                "resourceId": "function-id",
+            }
+        ).encode()
+
+        with patch(
+            "appwrite_console.client.requests.request", return_value=response
+        ) as request:
+            result = execute_registered_tool(
+                manager,
+                "functions_create_variable",
+                {
+                    "functionId": "function-id",
+                    "variableId": "variable-id",
+                    "key": "GREETING",
+                    "value": "",
+                },
+                client=client,
+            )
+
+        request.assert_called_once()
+        self.assertTrue(
+            request.call_args.kwargs["url"].endswith("/functions/function-id/variables")
+        )
+        self.assertEqual(
+            json.loads(request.call_args.kwargs["data"]),
+            {"variableId": "variable-id", "key": "GREETING", "value": ""},
+        )
+        self.assertEqual(json.loads(result[0].text)["$id"], "variable-id")
 
     def test_format_tool_result_serializes_json(self):
         result = _format_tool_result(


### PR DESCRIPTION
Missing required arguments to hidden SDK tools now produce a client-input error naming the missing fields before SDK execution. For example, calling `functions_create_variable` without `variable_id` previously raised an internal `TypeError`, even though the generated tool schema already marked that field required.

Validate the existing schema's required keys after argument alias normalization. Supplied IDs and empty values remain unchanged, and optional SDK defaults still apply. No resource IDs are generated implicitly.

Fixes [MCP-A](https://appwrite.sentry.io/issues/MCP-A).

Validation:
- Reproduced the reported missing-argument `TypeError` against the locked SDK. The public-handler regression fails without validation and passes with the fix.
- Tests exercise the public MCP call handler with real catalog metadata and a fake SDK service boundary. They assert returned input errors and successful results preserving supplied IDs, empty values, camelCase aliases, and omitted optional fields.
- Python 3.12: **257 unit tests passed**; Ruff, Black, Pyright, and Docker build passed.
- Integration discovery: **10 passed, 14 skipped** because Appwrite credentials were not configured.
