### PR TITLE
fix: handle generated SDK input validation

### DIFF
--- a/src/mcp_server_appwrite/error_classification.py
+++ b/src/mcp_server_appwrite/error_classification.py
@@ -17,6 +17,7 @@ ErrorCategory = Literal[
     "write_confirmation",
     "appwrite_4xx",
     "appwrite_5xx",
+    "sdk_input_validation",
     "sdk_validation",
     "response_too_large",
     "internal",
@@ -27,6 +28,7 @@ ERROR_CATEGORIES: frozenset[str] = frozenset(
         "write_confirmation",
         "appwrite_4xx",
         "appwrite_5xx",
+        "sdk_input_validation",
         "sdk_validation",
         "response_too_large",
         "internal",
@@ -83,6 +85,12 @@ def classify_tool_error(exc: BaseException) -> ErrorCategory:
     )
     if appwrite_error is not None:
         code = _appwrite_status_code(appwrite_error)
+        if (
+            code == 0
+            and appwrite_error.type == "sdk_input_validation"
+            and appwrite_error.response is None
+        ):
+            return "sdk_input_validation"
         if code is not None and 400 <= code < 500:
             return "appwrite_4xx"
         if code is not None and 500 <= code < 600:

--- a/src/mcp_server_appwrite/error_monitoring.py
+++ b/src/mcp_server_appwrite/error_monitoring.py
@@ -171,7 +171,7 @@ def _should_capture(exc: BaseException) -> bool:
         return False
 
     category = classify_tool_error(exc)
-    if category in {"write_confirmation", "appwrite_4xx"}:
+    if category in {"write_confirmation", "appwrite_4xx", "sdk_input_validation"}:
         return False
     # Pydantic validation errors are ValueError subclasses, but SDK response
     # validation is actionable model drift and must remain visible.

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -686,6 +686,16 @@ def _coerce_argument(param_name: str, value: Any, param_type: Any) -> Any:
     origin = get_origin(param_type)
     args = get_args(param_type)
 
+    if param_name == "queries" and origin is list:
+        if not isinstance(value, list) or any(
+            not isinstance(query, str) for query in value
+        ):
+            raise ValueError(
+                "'queries' must be an array of JSON strings, not query objects. "
+                "JSON-encode each query object before adding it to the array."
+            )
+        return value
+
     if param_type is InputFile:
         return _coerce_input_file(value, param_name)
 

--- a/src/mcp_server_appwrite/server.py
+++ b/src/mcp_server_appwrite/server.py
@@ -686,16 +686,6 @@ def _coerce_argument(param_name: str, value: Any, param_type: Any) -> Any:
     origin = get_origin(param_type)
     args = get_args(param_type)
 
-    if param_name == "queries" and origin is list:
-        if not isinstance(value, list) or any(
-            not isinstance(query, str) for query in value
-        ):
-            raise ValueError(
-                "'queries' must be an array of JSON strings, not query objects. "
-                "JSON-encode each query object before adding it to the array."
-            )
-        return value
-
     if param_type is InputFile:
         return _coerce_input_file(value, param_name)
 

--- a/tests/unit/test_error_classification.py
+++ b/tests/unit/test_error_classification.py
@@ -41,6 +41,31 @@ class ErrorClassificationTests(unittest.TestCase):
                     "appwrite_5xx",
                 )
 
+    def test_sdk_input_validation(self):
+        error = AppwriteException(
+            'Invalid parameter: "filters" must be an array of strings',
+            type="sdk_input_validation",
+        )
+        wrapped = RuntimeError("wrapped")
+        wrapped.__cause__ = error
+
+        for failure in (error, wrapped):
+            with self.subTest(failure=type(failure).__name__):
+                self.assertEqual(classify_tool_error(failure), "sdk_input_validation")
+
+    def test_sdk_input_validation_type_does_not_hide_responses(self):
+        for code, response, expected in (
+            (503, None, "appwrite_5xx"),
+            (0, {}, "internal"),
+            (0, "", "internal"),
+        ):
+            with self.subTest(code=code, response=response):
+                error = AppwriteException(
+                    "upstream failed", code, "sdk_input_validation", response
+                )
+
+                self.assertEqual(classify_tool_error(error), expected)
+
     def test_sdk_validation_takes_precedence_over_code(self):
         class Provider(BaseModel):
             options: dict
@@ -49,7 +74,7 @@ class ErrorClassificationTests(unittest.TestCase):
             Provider.model_validate({"options": []})
         except ValidationError as validation_error:
             appwrite_error = AppwriteException(
-                "Unable to parse response into Provider", 0, None
+                "Unable to parse response into Provider", 0, "sdk_input_validation"
             )
             appwrite_error.__cause__ = validation_error
         else:  # pragma: no cover - defensive

--- a/tests/unit/test_error_monitoring.py
+++ b/tests/unit/test_error_monitoring.py
@@ -70,16 +70,55 @@ class ErrorMonitoringTests(unittest.TestCase):
         capture.assert_not_called()
 
     def test_wrapped_sdk_validation_errors_are_captured(self):
+        error_monitoring._enabled = True
+
         class Payload(BaseModel):
             required: str
 
         try:
             Payload.model_validate({})
         except ValidationError as exc:
+            error = AppwriteException("invalid response", type="sdk_input_validation")
+            error.__cause__ = exc
             wrapped = RuntimeError("wrapped")
-            wrapped.__cause__ = exc
+            wrapped.__cause__ = error
 
-        self.assertTrue(error_monitoring._should_capture(wrapped))
+        with patch("sentry_sdk.capture_exception") as capture:
+            captured = error_monitoring.capture_exception(wrapped)
+
+        self.assertTrue(captured)
+        capture.assert_called_once_with(wrapped)
+
+    def test_sdk_input_validation_is_not_captured(self):
+        error_monitoring._enabled = True
+
+        for wrapped in (False, True):
+            with self.subTest(wrapped=wrapped):
+                error = AppwriteException(
+                    "invalid filters", type="sdk_input_validation"
+                )
+                failure = RuntimeError("wrapped") if wrapped else error
+                if wrapped:
+                    failure.__cause__ = error
+                with patch("sentry_sdk.capture_exception") as capture:
+                    captured = error_monitoring.capture_exception(failure)
+
+                self.assertFalse(captured)
+                capture.assert_not_called()
+
+    def test_sdk_input_validation_does_not_hide_unexpected_failures(self):
+        error_monitoring._enabled = True
+        for error in (
+            AppwriteException("network down"),
+            AppwriteException("upstream failed", 503, "sdk_input_validation"),
+            AppwriteException("invalid response", 0, "sdk_input_validation", {}),
+        ):
+            with self.subTest(error=error):
+                with patch("sentry_sdk.capture_exception") as capture:
+                    captured = error_monitoring.capture_exception(error)
+
+                self.assertTrue(captured)
+                capture.assert_called_once_with(error)
 
     def test_client_disconnects_are_not_captured(self):
         error_monitoring._enabled = True

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -5,10 +5,8 @@ import json
 import os
 import sys
 import tempfile
-import threading
 import time
 import unittest
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -100,34 +98,6 @@ class _FakeClient:
     def stream(self, method, url, **kwargs):
         self.stream_kwargs = {"method": method, "url": url, **kwargs}
         return _FakeStream(self._response)
-
-
-class _AppwriteServer(ThreadingHTTPServer):
-    def __init__(self, status, payload):
-        body = json.dumps(payload).encode()
-
-        class Handler(BaseHTTPRequestHandler):
-            def do_GET(self):
-                self.send_response(status)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
-
-            def log_message(self, *args):
-                pass
-
-        super().__init__(("127.0.0.1", 0), Handler)
-        self.thread = threading.Thread(target=self.serve_forever, daemon=True)
-
-    def __enter__(self):
-        self.thread.start()
-        return self
-
-    def __exit__(self, *args):
-        self.shutdown()
-        self.thread.join()
-        super().__exit__(*args)
 
 
 class ServerHelperTests(unittest.TestCase):
@@ -567,7 +537,7 @@ class ServerHelperTests(unittest.TestCase):
         with patch.dict(server_module.SERVICE_CLASSES, {"functions": FunctionsService}):
             asyncio.run(run_check())
 
-    def test_call_tool_returns_api_error_for_unencoded_queries(self):
+    def test_call_tool_returns_sdk_input_validation_for_unencoded_queries(self):
         client = build_introspection_client()
         manager = register_services(client, profile=API_KEY_PROFILE)
         server = build_mcp_server(build_operator(manager, client), transport="stdio")
@@ -604,22 +574,24 @@ class ServerHelperTests(unittest.TestCase):
                     result = await entry.handler(ctx, params)
 
                     self.assertTrue(result.is_error)
-                    self.assertIn("code=400", result.content[0].text)
-                    self.assertIn(
-                        "type=general_argument_invalid", result.content[0].text
-                    )
+                    self.assertIn("type=sdk_input_validation", result.content[0].text)
                     self.assertIn("queries", result.content[0].text)
+                    self.assertIn("string", result.content[0].text)
 
-        with _AppwriteServer(
-            400,
-            {
-                "message": "Invalid queries: query values must be strings",
-                "code": 400,
-                "type": "general_argument_invalid",
-            },
-        ) as api:
-            client.set_endpoint(f"http://127.0.0.1:{api.server_port}/v1")
+        with (
+            patch(
+                "requests.sessions.Session.request",
+                side_effect=AssertionError(
+                    "Invalid inputs must not send HTTP requests"
+                ),
+            ) as request,
+            patch.object(server_module.error_monitoring, "_enabled", True),
+            patch("sentry_sdk.capture_exception") as capture,
+        ):
             asyncio.run(run_check())
+
+        request.assert_not_called()
+        capture.assert_not_called()
 
     def test_call_tool_preserves_encoded_queries(self):
         client = build_introspection_client()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -16,7 +16,6 @@ from appwrite_console.enums.browser import Browser
 from appwrite_console.exception import AppwriteException
 from appwrite_console.input_file import InputFile
 from appwrite_console.models.row_list import RowList
-from requests import Response
 
 from mcp_server_appwrite import server as server_module
 from mcp_server_appwrite.catalog_policy import API_KEY_PROFILE, OAUTH_PROFILE
@@ -452,6 +451,13 @@ class ServerHelperTests(unittest.TestCase):
         entry = server.get_request_handler("tools/call")
         self.assertIsNotNone(entry)
 
+        class TablesDbService:
+            def __init__(self, client):
+                pass
+
+            def list_rows(self, **arguments):
+                return {"total": 0, "rows": []}
+
         async def run_check():
             ctx = Mock()
             ctx.protocol_version = "2026-07-28"
@@ -468,77 +474,76 @@ class ServerHelperTests(unittest.TestCase):
                 [1],
             ):
                 with self.subTest(queries=queries):
-                    arguments = {
-                        "database_id": "database-id",
-                        "table_id": "table-id",
-                        "queries": queries,
-                    }
-                    with patch("appwrite_console.client.requests.request") as request:
-                        with self.assertRaises(ValueError) as error:
-                            execute_registered_tool(
-                                manager,
-                                "tables_db_list_rows",
-                                arguments,
-                                client=client,
-                            )
-                        request.assert_not_called()
-                    self.assertIn("queries", str(error.exception))
                     params = types.CallToolRequestParams(
                         name="appwrite_call_tool",
                         arguments={
                             "tool_name": "tables_db_list_rows",
-                            "arguments": arguments,
+                            "arguments": {
+                                "database_id": "database-id",
+                                "table_id": "table-id",
+                                "queries": queries,
+                            },
                         },
                     )
-                    with patch("appwrite_console.client.requests.request") as request:
-                        result = await entry.handler(ctx, params)
+                    result = await entry.handler(ctx, params)
 
                     self.assertTrue(result.is_error)
                     self.assertIn("queries", result.content[0].text)
                     self.assertIn("JSON", result.content[0].text)
-                    request.assert_not_called()
 
-        asyncio.run(run_check())
+        with patch.dict(server_module.SERVICE_CLASSES, {"tables_db": TablesDbService}):
+            asyncio.run(run_check())
 
-    def test_execute_sdk_tool_preserves_encoded_queries(self):
+    def test_call_tool_preserves_encoded_queries(self):
         client = build_introspection_client()
         manager = register_services(client, profile=API_KEY_PROFILE)
-        response = Response()
-        response.status_code = 200
-        response.headers["Content-Type"] = "application/json"
-        response._content = b'{"total":0,"rows":[]}'
+        server = build_mcp_server(build_operator(manager, client), transport="stdio")
+        entry = server.get_request_handler("tools/call")
+        self.assertIsNotNone(entry)
         query = '{"method":"equal","attribute":"name","values":["Zoë"]}'
+        received_queries = []
 
-        for queries, expected in (
-            ([query], {"queries[0]": query}),
-            ([], {}),
-            (None, {}),
-        ):
-            with (
-                self.subTest(queries=queries),
-                patch(
-                    "appwrite_console.client.requests.request", return_value=response
-                ) as request,
+        class TablesDbService:
+            def __init__(self, client):
+                pass
+
+            def list_rows(self, database_id, table_id, queries=None):
+                received_queries.append(queries)
+                return {"total": 0, "rows": []}
+
+        async def run_check():
+            ctx = Mock()
+            ctx.protocol_version = "2026-07-28"
+            ctx.meta = None
+            ctx.session.client_params = None
+            for arguments, expected in (
+                ({"queries": [query]}, [query]),
+                ({"queries": []}, []),
+                ({"queries": None}, None),
+                ({}, None),
             ):
-                result = execute_registered_tool(
-                    manager,
-                    "tables_db_list_rows",
-                    {
-                        "database_id": "database-id",
-                        "table_id": "table-id",
-                        "queries": queries,
-                    },
-                    client=client,
-                )
-
-                request.assert_called_once()
-                self.assertTrue(
-                    request.call_args.kwargs["url"].endswith(
-                        "/tablesdb/database-id/tables/table-id/rows"
+                with self.subTest(arguments=arguments):
+                    params = types.CallToolRequestParams(
+                        name="appwrite_call_tool",
+                        arguments={
+                            "tool_name": "tables_db_list_rows",
+                            "arguments": {
+                                "database_id": "database-id",
+                                "table_id": "table-id",
+                                **arguments,
+                            },
+                        },
                     )
-                )
-                self.assertEqual(request.call_args.kwargs["params"], expected)
-                self.assertEqual(json.loads(result[0].text), {"total": 0, "rows": []})
+                    result = await entry.handler(ctx, params)
+
+                    self.assertFalse(result.is_error)
+                    self.assertEqual(received_queries[-1], expected)
+                    self.assertEqual(
+                        json.loads(result.content[0].text), {"total": 0, "rows": []}
+                    )
+
+        with patch.dict(server_module.SERVICE_CLASSES, {"tables_db": TablesDbService}):
+            asyncio.run(run_check())
 
     def test_format_tool_result_serializes_json(self):
         result = _format_tool_result(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -5,8 +5,10 @@ import json
 import os
 import sys
 import tempfile
+import threading
 import time
 import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -98,6 +100,34 @@ class _FakeClient:
     def stream(self, method, url, **kwargs):
         self.stream_kwargs = {"method": method, "url": url, **kwargs}
         return _FakeStream(self._response)
+
+
+class _AppwriteServer(ThreadingHTTPServer):
+    def __init__(self, status, payload):
+        body = json.dumps(payload).encode()
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):
+                pass
+
+        super().__init__(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *args):
+        self.shutdown()
+        self.thread.join()
+        super().__exit__(*args)
 
 
 class ServerHelperTests(unittest.TestCase):
@@ -537,19 +567,12 @@ class ServerHelperTests(unittest.TestCase):
         with patch.dict(server_module.SERVICE_CLASSES, {"functions": FunctionsService}):
             asyncio.run(run_check())
 
-    def test_call_tool_rejects_unencoded_queries_before_sdk_execution(self):
+    def test_call_tool_returns_api_error_for_unencoded_queries(self):
         client = build_introspection_client()
         manager = register_services(client, profile=API_KEY_PROFILE)
         server = build_mcp_server(build_operator(manager, client), transport="stdio")
         entry = server.get_request_handler("tools/call")
         self.assertIsNotNone(entry)
-
-        class TablesDbService:
-            def __init__(self, client):
-                pass
-
-            def list_rows(self, **arguments):
-                return {"total": 0, "rows": []}
 
         async def run_check():
             ctx = Mock()
@@ -581,10 +604,21 @@ class ServerHelperTests(unittest.TestCase):
                     result = await entry.handler(ctx, params)
 
                     self.assertTrue(result.is_error)
+                    self.assertIn("code=400", result.content[0].text)
+                    self.assertIn(
+                        "type=general_argument_invalid", result.content[0].text
+                    )
                     self.assertIn("queries", result.content[0].text)
-                    self.assertIn("JSON", result.content[0].text)
 
-        with patch.dict(server_module.SERVICE_CLASSES, {"tables_db": TablesDbService}):
+        with _AppwriteServer(
+            400,
+            {
+                "message": "Invalid queries: query values must be strings",
+                "code": 400,
+                "type": "general_argument_invalid",
+            },
+        ) as api:
+            client.set_endpoint(f"http://127.0.0.1:{api.server_port}/v1")
             asyncio.run(run_check())
 
     def test_call_tool_preserves_encoded_queries(self):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -16,6 +16,7 @@ from appwrite_console.enums.browser import Browser
 from appwrite_console.exception import AppwriteException
 from appwrite_console.input_file import InputFile
 from appwrite_console.models.row_list import RowList
+from requests import Response
 
 from mcp_server_appwrite import server as server_module
 from mcp_server_appwrite.catalog_policy import API_KEY_PROFILE, OAUTH_PROFILE
@@ -443,6 +444,101 @@ class ServerHelperTests(unittest.TestCase):
                     "maximumFileSize": 10_485_760,
                 },
             )
+
+    def test_call_tool_rejects_unencoded_queries_before_sdk_execution(self):
+        client = build_introspection_client()
+        manager = register_services(client, profile=API_KEY_PROFILE)
+        server = build_mcp_server(build_operator(manager, client), transport="stdio")
+        entry = server.get_request_handler("tools/call")
+        self.assertIsNotNone(entry)
+
+        async def run_check():
+            ctx = Mock()
+            ctx.protocol_version = "2026-07-28"
+            ctx.meta = None
+            ctx.session.client_params = None
+            for queries in (
+                [{"method": "limit", "values": [1]}],
+                [
+                    '{"method":"limit","values":[1]}',
+                    {"method": "offset", "values": [1]},
+                ],
+                {"method": "limit", "values": [1]},
+                '{"method":"limit","values":[1]}',
+                [1],
+            ):
+                with self.subTest(queries=queries):
+                    arguments = {
+                        "database_id": "database-id",
+                        "table_id": "table-id",
+                        "queries": queries,
+                    }
+                    with patch("appwrite_console.client.requests.request") as request:
+                        with self.assertRaises(ValueError) as error:
+                            execute_registered_tool(
+                                manager,
+                                "tables_db_list_rows",
+                                arguments,
+                                client=client,
+                            )
+                        request.assert_not_called()
+                    self.assertIn("queries", str(error.exception))
+                    params = types.CallToolRequestParams(
+                        name="appwrite_call_tool",
+                        arguments={
+                            "tool_name": "tables_db_list_rows",
+                            "arguments": arguments,
+                        },
+                    )
+                    with patch("appwrite_console.client.requests.request") as request:
+                        result = await entry.handler(ctx, params)
+
+                    self.assertTrue(result.is_error)
+                    self.assertIn("queries", result.content[0].text)
+                    self.assertIn("JSON", result.content[0].text)
+                    request.assert_not_called()
+
+        asyncio.run(run_check())
+
+    def test_execute_sdk_tool_preserves_encoded_queries(self):
+        client = build_introspection_client()
+        manager = register_services(client, profile=API_KEY_PROFILE)
+        response = Response()
+        response.status_code = 200
+        response.headers["Content-Type"] = "application/json"
+        response._content = b'{"total":0,"rows":[]}'
+        query = '{"method":"equal","attribute":"name","values":["Zoë"]}'
+
+        for queries, expected in (
+            ([query], {"queries[0]": query}),
+            ([], {}),
+            (None, {}),
+        ):
+            with (
+                self.subTest(queries=queries),
+                patch(
+                    "appwrite_console.client.requests.request", return_value=response
+                ) as request,
+            ):
+                result = execute_registered_tool(
+                    manager,
+                    "tables_db_list_rows",
+                    {
+                        "database_id": "database-id",
+                        "table_id": "table-id",
+                        "queries": queries,
+                    },
+                    client=client,
+                )
+
+                request.assert_called_once()
+                self.assertTrue(
+                    request.call_args.kwargs["url"].endswith(
+                        "/tablesdb/database-id/tables/table-id/rows"
+                    )
+                )
+                self.assertEqual(request.call_args.kwargs["params"], expected)
+                self.assertEqual(json.loads(result[0].text), {"total": 0, "rows": []})
 
     def test_format_tool_result_serializes_json(self):
         result = _format_tool_result(


### PR DESCRIPTION
Draft: blocked on publishing an `appwrite-console` release containing [sdk-generator#1899](https://github.com/appwrite/sdk-generator/pull/1899) and [sdk-for-console-python#10](https://github.com/appwrite/sdk-for-console-python/pull/10), then updating MCP's dependency requirement and lockfile to that real release. The lockfile still contains 0.6.0, which does not provide these guards. The new public-handler regression therefore fails with the currently locked dependency; this PR is not ready to merge.

Passing query objects where the SDK expects a list of strings previously raised `can only concatenate str (not "dict") to str`. The generated SDK now validates string-array parameters from their OpenAPI schemas before serialization and raises `AppwriteException(type="sdk_input_validation")` with code 0 and no response. MCP returns that readable error and treats this precise local validation contract as an expected caller failure. Server failures, untyped SDK errors, and response-parsing failures remain reportable.

The earlier query-specific MCP guard is removed. Tests call the public MCP handler with the real SDK, verify malformed inputs produce an error before HTTP and without a Sentry event, and retain the existing valid-query argument checks for Unicode, empty lists, null, and omission.

Fixes [MCP-X](https://appwrite.sentry.io/issues/MCP-X).

Validation:

- Python 3.12: all 263 unit tests pass using a temporary source overlay of the generated SDK changes. Installed dependencies and the lockfile were unchanged.
- With locked `appwrite-console==0.6.0`, the new regression fails for all five malformed-input cases; all 262 other tests pass. The transport boundary is blocked, so this check sends no HTTP requests.
- Classification and monitoring regressions verify raw and wrapped local validation errors are ignored, while 5xx errors, untyped failures, and Pydantic response errors remain visible.
- Ruff, Black, Pyright, `git diff --check`, and the normal Docker build pass. CI unit tests remain dependency-blocked until the published SDK is pinned.
