### PR TITLE
fix: serve OpenAI domain verification challenge

### DIFF
--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -13,6 +13,7 @@ Builds a single-tenant Starlette ASGI app for the served Appwrite project:
   following ``resource_metadata`` from the 401 challenge. Mirrors the Appwrite
   authorization server's discovery document verbatim.
 * ``/healthz`` — liveness probe.
+* ``/.well-known/openai-apps-challenge`` — public domain verification token.
 
 Auth uses the SDK primitives (``BearerAuthBackend`` + ``AuthContextMiddleware``) so the
 validated token is reachable from tool handlers via ``get_access_token()``.
@@ -438,6 +439,11 @@ async def health_endpoint(request: Request) -> PlainTextResponse:
     return PlainTextResponse(f"appwrite-mcp {SERVER_VERSION} ok")
 
 
+async def openai_apps_challenge_endpoint(request: Request) -> PlainTextResponse:
+    """Serve the public domain-ownership challenge for the OpenAI app listing."""
+    return PlainTextResponse("Fv03Ea1-vV7p7oIpvL3y2bRKrxVBJnSmscrDOdsVRuk")
+
+
 async def favicon_svg_endpoint(request: Request) -> Response:
     return Response(
         _icon_svg(),
@@ -477,6 +483,11 @@ def build_app() -> Starlette:
             yield
 
     routes = [
+        Route(
+            "/.well-known/openai-apps-challenge",
+            endpoint=openai_apps_challenge_endpoint,
+            methods=["GET"],
+        ),
         Route(
             "/.well-known/oauth-protected-resource/mcp",
             endpoint=mcp_path_protected_resource_metadata_endpoint,

--- a/tests/unit/test_http_app.py
+++ b/tests/unit/test_http_app.py
@@ -333,7 +333,8 @@ class WellKnownMetadataEndpointTests(unittest.TestCase):
         self.assertEqual(
             response.content, b"Fv03Ea1-vV7p7oIpvL3y2bRKrxVBJnSmscrDOdsVRuk"
         )
-        self.assertEqual(response.headers["content-type"], "text/plain; charset=utf-8")
+        media_type = response.headers["content-type"].split(";", 1)[0].strip()
+        self.assertEqual(media_type, "text/plain")
 
 
 class ConsoleOverrideTests(unittest.TestCase):

--- a/tests/unit/test_http_app.py
+++ b/tests/unit/test_http_app.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from starlette.testclient import TestClient
 
 from mcp_server_appwrite import auth, telemetry
 from mcp_server_appwrite.http_app import (
@@ -316,6 +317,23 @@ class WellKnownMetadataEndpointTests(unittest.TestCase):
         self.assertIn("/.well-known/oauth-protected-resource/mcp", paths)
         self.assertIn("/.well-known/oauth-protected-resource", paths)
         self.assertIn("/.well-known/oauth-authorization-server", paths)
+
+    def test_openai_challenge_is_public_plain_text(self):
+        from mcp_server_appwrite import server as server_module
+
+        original_transport = server_module._UPLOAD_TRANSPORT
+        self.addCleanup(setattr, server_module, "_UPLOAD_TRANSPORT", original_transport)
+
+        with TestClient(build_app()) as client:
+            response = client.get(
+                "/.well-known/openai-apps-challenge", follow_redirects=False
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.content, b"Fv03Ea1-vV7p7oIpvL3y2bRKrxVBJnSmscrDOdsVRuk"
+        )
+        self.assertEqual(response.headers["content-type"], "text/plain; charset=utf-8")
 
 
 class ConsoleOverrideTests(unittest.TestCase):


### PR DESCRIPTION
﻿OpenAI domain verification currently has no challenge endpoint on the hosted MCP server. Serve the supplied public verification token at `GET /.well-known/openai-apps-challenge` as plain text without requiring bearer authentication, allowing verification after deployment to `mcp.appwrite.io`.

Validation:
- Ruff and Black checks passed for `src` and `tests`.
- Pyright passed with `--pythonplatform Linux` (the CI target).
- All 32 HTTP unit tests passed; an unauthenticated TestClient request returned HTTP 200 with the exact token and `text/plain`.
- Full unit suite attempted: 247 tests, with one import error from unavailable Windows `fcntl` and one system CPU gauge failure. Native Windows Pyright also reports Unix-only API errors.
- Docker build could not run because the local Docker daemon is unavailable. Live integration tests were not run; CI validation remains pending.
