### PR TITLE
fix: correct OpenAI domain verification token

### DIFF
--- a/src/mcp_server_appwrite/http_app.py
+++ b/src/mcp_server_appwrite/http_app.py
@@ -441,7 +441,7 @@ async def health_endpoint(request: Request) -> PlainTextResponse:
 
 async def openai_apps_challenge_endpoint(request: Request) -> PlainTextResponse:
     """Serve the public domain-ownership challenge for the OpenAI app listing."""
-    return PlainTextResponse("Fv03Ea1-vV7p7oIpvL3y2bRKrxVBJnSmscrDOdsVRuk")
+    return PlainTextResponse("Fv03Eal-vV7p7oIpvL3y2bRKrxVBJrSmscrDOdsVRuk")
 
 
 async def favicon_svg_endpoint(request: Request) -> Response:

--- a/tests/unit/test_http_app.py
+++ b/tests/unit/test_http_app.py
@@ -331,7 +331,7 @@ class WellKnownMetadataEndpointTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.content, b"Fv03Ea1-vV7p7oIpvL3y2bRKrxVBJnSmscrDOdsVRuk"
+            response.content, b"Fv03Eal-vV7p7oIpvL3y2bRKrxVBJrSmscrDOdsVRuk"
         )
         media_type = response.headers["content-type"].split(";", 1)[0].strip()
         self.assertEqual(media_type, "text/plain")


### PR DESCRIPTION
## Summary

Corrects the token served at `/.well-known/openai-apps-challenge`. The value shipped in #119 had two mistyped characters, so OpenAI domain verification would fail against the deployed endpoint. The unit test's expected body is updated to match.

## Testing

- `black --check src tests`
- `ruff check src tests`
- `python -m unittest tests.unit.test_http_app` (33 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)